### PR TITLE
Fallback to remote reel poster images

### DIFF
--- a/SendMoi/Services/GmailDeliveryService.swift
+++ b/SendMoi/Services/GmailDeliveryService.swift
@@ -715,7 +715,18 @@ final class GmailDeliveryService {
     }
 
     private static func preferredDisplayImageSources(for content: EmailContent) -> [String] {
-        content.inlineImages.map { "cid:\($0.contentID)" }
+        guard !content.imageURLStrings.isEmpty else {
+            return content.inlineImages.map { "cid:\($0.contentID)" }
+        }
+
+        return content.imageURLStrings.enumerated().compactMap { index, imageURLString in
+            if content.inlineImages.indices.contains(index) {
+                return "cid:\(content.inlineImages[index].contentID)"
+            }
+
+            let trimmed = imageURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
     }
 
     private static func makeTitleMarkup(content: EmailContent, fontFamily: String) -> String {


### PR DESCRIPTION
## Summary
- fall back to the original image URL when an inline CID image is unavailable
- preserve the existing inline-image behavior when the attachment fetch succeeds
- keep Instagram reel shares from rendering as text-only cards when Instagram only exposes an og:image poster

## Testing
- xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build