### PR TITLE
Scale summaries to page length

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,6 @@
 # SendMoi Handoff
 
-Last updated: March 5, 2026
+Last updated: March 7, 2026
 
 ## Current State
 
@@ -26,6 +26,7 @@ Last updated: March 5, 2026
   - linked headline is no longer permanently underlined
   - summary preamble cleanup was added
   - preview image and summary handling were improved
+  - summary length now scales with extracted page text length so shorter pages get shorter blurbs instead of forcing article-sized summaries
 - Added:
   - `PRIVACY.md`
   - `TERMS.md`

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For reachable web URLs, SendMoi attempts to enrich the message before sending:
 
 - Uses the page `<title>` when available, with sensible metadata fallbacks.
 - Pulls a page description when one is available.
-- Generates a short summary when enough high-quality body content is available.
+- Generates a short summary when enough high-quality body content is available, sizing the blurb to the amount of source text instead of always forcing an article-length recap.
 - Inlines a preview image when the page exposes one and the image fetch succeeds.
 - Renders the HTML email as a responsive card layout for desktop and mobile clients.
 - Normalizes common shared-post formats, including X/Twitter share text and Overcast titles, before building the email.

--- a/SendMoi/Services/GmailDeliveryService.swift
+++ b/SendMoi/Services/GmailDeliveryService.swift
@@ -1699,12 +1699,23 @@ final class GmailDeliveryService {
             return nil
         }
 
-        if let aiSummary = await summarizeWithFoundationModels(cleanedText, title: title, minWords: 75, maxWords: 100) {
+        let summaryWordRange = summaryWordRange(for: cleanedText)
+
+        if let aiSummary = await summarizeWithFoundationModels(
+            cleanedText,
+            title: title,
+            minWords: summaryWordRange.minWords,
+            maxWords: summaryWordRange.maxWords
+        ) {
             let normalized = stripSummaryPreamble(from: aiSummary, title: title)
             return passesSummaryOutputQualityGate(normalized) ? normalized : nil
         }
 
-        guard let fallbackSummary = summarize(cleanedText, minWords: 75, maxWords: 100) else {
+        guard let fallbackSummary = summarize(
+            cleanedText,
+            minWords: summaryWordRange.minWords,
+            maxWords: summaryWordRange.maxWords
+        ) else {
             return nil
         }
 
@@ -2131,6 +2142,19 @@ final class GmailDeliveryService {
         }
 
         return selectedSentences.joined(separator: " ")
+    }
+
+    private static func summaryWordRange(for text: String) -> (minWords: Int, maxWords: Int) {
+        let sourceWordCount = wordCount(in: text)
+
+        switch sourceWordCount {
+        case ..<300:
+            return (minWords: 20, maxWords: 40)
+        case ..<800:
+            return (minWords: 40, maxWords: 70)
+        default:
+            return (minWords: 75, maxWords: 100)
+        }
     }
 
     private static func splitIntoSentences(_ text: String) -> [String] {


### PR DESCRIPTION
## Summary
- scale generated summary length based on the amount of extracted source text
- keep short pages and landing pages from being forced into article-sized summaries
- update README and HANDOFF notes for the new summary behavior

## Testing
- xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build