### PR TITLE
Adjust onboarding action grouping and issue prefixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,12 @@
 - Update `README.md` whenever setup steps, commands, behavior, or other user-facing documentation changed.
 - Update `HANDOFF.md` whenever the working branch, current focus, recent changes, open items, or resume steps changed.
 - Do not finalize a commit until those files are either updated or explicitly confirmed to still be accurate.
+
+## GitHub Issues Workflow
+- Treat messages prefixed with `BUG:` or `ISSUE:` as a request to create a GitHub issue directly.
+- Classify issue type and labels based on context (for example: `bug`, `enhancement`, `chore`) unless the user explicitly forces a type.
+- If the user includes a type hint inline (for example: `ISSUE: [bug] ...`), honor it.
+- If required details are missing, ask a short follow-up question before creating the issue.
+- If the user provides screenshots/videos, include them in the issue:
+  - use existing URLs directly when available
+  - otherwise upload media into the repo (for example under `docs/bugs/...`) and link it in the issue body.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,10 +1,10 @@
 # SendMoi Handoff
 
-Last updated: March 5, 2026
+Last updated: March 7, 2026
 
 ## Current State
 
-- Repo: `main`
+- Repo: `codex/onboarding-actions-and-issue-prefix`
 - Latest intended app version: `0.3`
 - Recent shipped commits:
   - `334a80e` `Separate recipient settings from account`
@@ -31,6 +31,8 @@ Last updated: March 5, 2026
   - `TERMS.md`
   - iOS launch screen asset and storyboard (`Splash.imageset`, `LaunchScreen.storyboard`)
 - `README.md` now reflects current behavior instead of hardcoding the old `0.1` release framing.
+- `AGENTS.md` now treats `BUG:` and `ISSUE:` as the explicit GitHub issue creation prefixes.
+- The onboarding footer now leaves `Skip` on its own and groups `Back` with the trailing primary action.
 - New in the current working tree:
   - repo-wide rename from MailMoi to SendMoi: project, targets, schemes, folders, and user-facing copy
   - bundle identifiers, App Group ID, and shared container/keychain storage identifiers intentionally remain on the existing MailMoi values for upgrade continuity

--- a/SendMoi/ContentView.swift
+++ b/SendMoi/ContentView.swift
@@ -280,24 +280,26 @@ struct ContentView: View {
                 .foregroundStyle(.primary)
                 .controlSize(.large)
 
-                if onboardingStep > 0 {
-                    Button("Back") {
-                        onboardingStep -= 1
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(onboardingSecondaryButtonTint)
-                    .foregroundStyle(.primary)
-                    .controlSize(.large)
-                }
-
                 Spacer(minLength: 0)
 
-                Button(onboardingPrimaryButtonTitle) {
-                    handleOnboardingPrimaryAction()
+                HStack(spacing: 12) {
+                    if onboardingStep > 0 {
+                        Button("Back") {
+                            onboardingStep -= 1
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(onboardingSecondaryButtonTint)
+                        .foregroundStyle(.primary)
+                        .controlSize(.large)
+                    }
+
+                    Button(onboardingPrimaryButtonTitle) {
+                        handleOnboardingPrimaryAction()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .disabled(onboardingStep == 2 && model.session == nil && !GoogleOAuthConfig.isConfigured)
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .disabled(onboardingStep == 2 && model.session == nil && !GoogleOAuthConfig.isConfigured)
             }
         }
     }


### PR DESCRIPTION
## Summary
- leave Skip on its own in the onboarding footer and group Back with the trailing primary action
- add BUG: and ISSUE: as explicit GitHub issue creation prefixes in AGENTS.md
- update HANDOFF.md for the new branch and recent changes

## Testing
- xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -destination 'generic/platform=iOS' build