### PR TITLE
Fix missing cancel action in reset settings prompt

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -19,6 +19,7 @@ Last updated: March 7, 2026
 - First-run now presents a branded 3-step setup guide as a modal instead of replacing the app shell, and setup can be reopened later from the dedicated bottom `Setup` actions.
 - The onboarding finish step now shows the connected Gmail account, allows `Switch Account`, uses an explicit recipient `Save` action, and only reveals auto-send when a saved recipient is active.
 - The onboarding action row was normalized so the primary action stays pinned and `View Settings` appears as a full-width secondary control on the final step.
+- The `Clear Settings` reset confirmation now uses a standard alert so iPhone shows a visible `Cancel` action alongside the destructive button.
 - The share-extension `Auto-Sending...` overlay card now uses a softer translucent material treatment.
 - If `Auto-send` is off, the share extension stays open and pre-fills the draft rather than sending immediately.
 - The desktop app includes a compose card again; the missing `desktopComposeCard` helper was restored so the macOS workspace compiles, but the card is informational only and points users back to the share sheet for actual drafting.

--- a/SendMoi/ContentView.swift
+++ b/SendMoi/ContentView.swift
@@ -90,18 +90,18 @@ struct ContentView: View {
                     .environmentObject(model)
             }
         }
-        .confirmationDialog(
+        .alert(
             "Reset SendMoi?",
             isPresented: $showsResetConfirmation,
-            titleVisibility: .visible
-        ) {
+            actions: {
             Button("Clear Settings", role: .destructive) {
                 clearSettingsAndRestartSetup()
             }
             Button("Cancel", role: .cancel) { }
-        } message: {
+        },
+            message: {
             Text("This disconnects Gmail, clears saved defaults, and reopens setup. Queued items stay in place.")
-        }
+        })
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- switch the reset confirmation from a confirmation dialog to a standard alert
- keep the destructive Clear Settings action and visible Cancel action together on iPhone
- update handoff notes for the UI fix

## Testing
- xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -destination "generic/platform=iOS Simulator" build

Fixes #6