### PR TITLE
Start Gmail sign-in directly from the share sheet

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,7 +4,7 @@ Last updated: March 7, 2026
 
 ## Current State
 
-- Repo: `codex/onboarding-actions-and-issue-prefix`
+- Repo: `codex/share-sheet-gmail-signin`
 - Latest intended app version: `0.3`
 - Recent shipped commits:
   - `334a80e` `Separate recipient settings from account`
@@ -55,6 +55,7 @@ Last updated: March 7, 2026
   - the share extension processing state now says `Auto-Sending...`, keeps `Edit` available for a 0.5-second grace period before auto-send starts, and uses a roomier bordered `Edit` action that still cancels auto-send and returns to the draft without changing the saved preference
   - manual sends now queue first and dismiss the sheet immediately, then continue best-effort preview enrichment and delivery in the background; if that work does not finish, the queued item remains for later retry
   - if no default recipient is saved, the share extension now shows a specific inline `To` warning and keeps `Send` disabled until a recipient is entered instead of falling back to the generic validation error
+  - if Gmail is not connected, the share sheet now stops before auto-send, presents a `Connect Gmail in SendMoi` alert, and can start Google sign-in directly from the share sheet so queued items can resume sending with less ambiguity
   - refreshed the SendMoi icon source in `marketing/send-moi.icon` and `SendMoi/send-moi.icon`, regenerated every `AppIcon.appiconset` size from the updated 1024 master PNG, and updated marketing icon exports in this repo
 
 ## Things To Verify On The Next Machine
@@ -72,6 +73,7 @@ Last updated: March 7, 2026
 9. Run `./scripts/prepare_release.sh --version <next-version>` before the next archive, then verify App Store Connect accepts the `AppIcon` set for both iOS and macOS, shows the expected branded thumbnail, and no longer includes `send-moi.icon` as an extra bundled resource.
 10. Confirm the next Xcode Cloud upload succeeds with build number `3`; the previous failure was `The bundle version must be higher than the previously uploaded version.`
 11. After the next icon refresh, run `./scripts/prune_app_icon_set.sh` and confirm Xcode no longer shows `AppIcon` asset warnings before archiving.
+12. Launch the share sheet while signed out of Gmail and confirm the new connect alert appears, starts Google sign-in from the share sheet itself, and resumes sending without implying that auto-send already happened.
 
 ## Local Setup
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ The `SendMoiShare` extension is included for iPhone, iPad, and macOS share sheet
 - It accepts URL, text, image, HTML, and JavaScript-preprocessed share payloads from the host app.
 - It reads the title, description, URL, and first shared image from the shared item when the host app provides them.
 - For X/Twitter shares, it can rewrite noisy shared text into a cleaner draft and canonicalize tweet URLs before fetching preview metadata.
+- If Gmail is not connected, the share sheet shows a `Connect Gmail in SendMoi` alert and can start the Google sign-in flow directly from the share sheet.
 - If `Auto-send` is enabled and a default recipient is already saved, it waits 0.5 seconds after the draft is ready, then tries to send automatically.
 - While auto-send is in progress, the sheet shows an `Auto-Sending...` state with a secondary `Edit` action that stays available during that 0.5-second grace period and still cancels the in-flight auto-send attempt without changing the saved `Auto-send` preference.
+- If Gmail is not connected yet, automatic sending is held back so the share sheet does not imply that delivery is already underway.
 - If you tap `Send`, SendMoi first saves the draft to the queue, dismisses the sheet immediately, and then continues best-effort preview enrichment and delivery in the background. If that background work does not finish, the queued item is retried later.
 - If `Auto-send` is disabled, it stays open and pre-fills the draft so you can review before sending.
 - If no default recipient is saved, the share sheet keeps `Send` disabled, shows an inline `To`-field warning, and asks you to enter a recipient before it will queue or send anything.

--- a/SendMoiShare/ShareExtensionModel.swift
+++ b/SendMoiShare/ShareExtensionModel.swift
@@ -7,6 +7,7 @@ final class ShareExtensionModel: ObservableObject {
     private static let autoSendGracePeriodNanoseconds: UInt64 = 1_000_000_000
     private static let manualSendPreviewWaitLimitNanoseconds: UInt64 = 750_000_000
     static let missingRecipientMessage = "Enter a recipient in the To field, or set a default recipient in the SendMoi app."
+    private static let connectGmailStatusMessage = "Connect Gmail to send from the share sheet. You can still queue this share and send it after sign-in."
 
     enum PresentationMode: Equatable {
         case processing
@@ -23,9 +24,11 @@ final class ShareExtensionModel: ObservableObject {
     @Published var statusMessage = "Preparing your email..."
     @Published private(set) var autoSendEnabled = true
     @Published var isSaving = false
+    @Published var isConnectingGmail = false
     @Published var isRefreshingPreview = false
     @Published var savedRecipients: [String] = []
     @Published var presentationMode: PresentationMode = .processing
+    @Published var showsGmailConnectAlert = false
 
     private weak var extensionContextRef: NSExtensionContext?
     private let deliveryService = GmailDeliveryService()
@@ -33,6 +36,8 @@ final class ShareExtensionModel: ObservableObject {
     private var sendTask: Task<Void, Never>?
     private var pendingPreviewApplication: PendingPreviewApplication?
     private var queuedPreviewEnrichmentItem: QueuedEmail?
+    private var hasPromptedForGmailConnection = false
+    var requestGmailConnection: (@MainActor () async throws -> GmailSession)?
 
     func attach(extensionContext: NSExtensionContext?) {
         extensionContextRef = extensionContext
@@ -53,6 +58,7 @@ final class ShareExtensionModel: ObservableObject {
             apply(content)
             schedulePreviewRefresh()
             autoSendIfPossible()
+            promptForGmailConnectionIfNeeded()
         }
     }
 
@@ -127,6 +133,34 @@ final class ShareExtensionModel: ObservableObject {
         schedulePreviewRefresh()
     }
 
+    func connectGmail() {
+        guard !isConnectingGmail else { return }
+
+        showsGmailConnectAlert = false
+        isConnectingGmail = true
+        statusMessage = "Connecting Gmail..."
+
+        Task { [weak self] in
+            guard let self else { return }
+            defer { self.isConnectingGmail = false }
+
+            do {
+                guard let requestGmailConnection else {
+                    throw GmailAPIError.authorizationFailed("Google sign-in is not available in this share sheet.")
+                }
+
+                let session = try await requestGmailConnection()
+                try SharedSessionStore.save(session)
+                statusMessage = "Connected as \(session.emailAddress ?? "your Gmail account")."
+                autoSendIfPossible()
+            } catch GmailAPIError.signInCanceled {
+                statusMessage = Self.connectGmailStatusMessage
+            } catch {
+                statusMessage = "Could not connect Gmail: \(error.localizedDescription)"
+            }
+        }
+    }
+
     var recipientValidationMessage: String? {
         let trimmedRecipient = toEmail.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmedRecipient.isEmpty else {
@@ -192,6 +226,9 @@ final class ShareExtensionModel: ObservableObject {
         if title.isEmpty && excerpt.isEmpty && urlString.isEmpty && allImageURLStrings.isEmpty {
             statusMessage = "Nothing was extracted automatically. You can still fill it in manually."
             presentationMode = .editing
+        } else if !hasSharedGmailSession {
+            statusMessage = Self.connectGmailStatusMessage
+            presentationMode = .editing
         } else if toEmail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             statusMessage = Self.missingRecipientMessage
             presentationMode = .editing
@@ -221,6 +258,18 @@ final class ShareExtensionModel: ObservableObject {
 
         if draft.toEmail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             statusMessage = Self.missingRecipientMessage
+            presentationMode = .editing
+            return
+        }
+
+        if isConnectingGmail {
+            statusMessage = "Connecting Gmail..."
+            presentationMode = .editing
+            return
+        }
+
+        guard hasSharedGmailSession else {
+            statusMessage = Self.connectGmailStatusMessage
             presentationMode = .editing
             return
         }
@@ -543,6 +592,23 @@ final class ShareExtensionModel: ObservableObject {
         }
 
         return nil
+    }
+
+    private var hasSharedGmailSession: Bool {
+        do {
+            return try SharedSessionStore.load() != nil
+        } catch {
+            return false
+        }
+    }
+
+    private func promptForGmailConnectionIfNeeded() {
+        guard !hasPromptedForGmailConnection, !hasSharedGmailSession else {
+            return
+        }
+
+        hasPromptedForGmailConnection = true
+        showsGmailConnectAlert = true
     }
 
     private static func shouldApplyPreviewTitle(existingTitle: String, urlString: String) -> Bool {

--- a/SendMoiShare/ShareView.swift
+++ b/SendMoiShare/ShareView.swift
@@ -50,6 +50,14 @@ struct ShareView: View {
                 }
             }
         }
+        .alert("Connect Gmail in SendMoi", isPresented: $model.showsGmailConnectAlert) {
+            Button("Sign In to Gmail") {
+                model.connectGmail()
+            }
+            Button("Not Now", role: .cancel) {}
+        } message: {
+            Text("SendMoi is not connected to Gmail on this device yet. Sign in now to send from this share sheet, or choose Not Now and this share will stay queued until you connect Gmail later.")
+        }
         #if os(macOS)
         .frame(minWidth: 480, idealWidth: 520, minHeight: 420, idealHeight: 460)
         #endif
@@ -160,7 +168,7 @@ struct ShareView: View {
                 statusMessageView
             }
         }
-        .disabled(model.isSaving)
+        .disabled(model.isSaving || model.isConnectingGmail)
     }
 
     private var previewThumbnail: some View {
@@ -418,7 +426,7 @@ struct ShareView: View {
     }
 
     private var sendButtonDisabled: Bool {
-        model.presentationMode != .editing || model.isSaving || model.recipientValidationMessage != nil
+        model.presentationMode != .editing || model.isSaving || model.isConnectingGmail || model.recipientValidationMessage != nil
     }
 
     private var overlayBorderColor: Color {

--- a/SendMoiShare/ShareViewController.swift
+++ b/SendMoiShare/ShareViewController.swift
@@ -1,3 +1,5 @@
+import AuthenticationServices
+import CryptoKit
 import SwiftUI
 
 #if os(iOS)
@@ -12,6 +14,7 @@ typealias PlatformHostingController<Content: View> = NSHostingController<Content
 
 final class ShareViewController: PlatformViewController {
     private let model = ShareExtensionModel()
+    private lazy var gmailAuthenticator = ShareExtensionGoogleAuthenticator(presentingViewController: self)
 
     #if os(macOS)
     private let preferredExtensionSize = NSSize(width: 520, height: 460)
@@ -27,6 +30,13 @@ final class ShareViewController: PlatformViewController {
         super.viewDidLoad()
 
         model.attach(extensionContext: extensionContext)
+        model.requestGmailConnection = { [weak self] in
+            guard let self else {
+                throw GmailAPIError.authorizationFailed("Google sign-in is no longer available.")
+            }
+
+            return try await self.gmailAuthenticator.signIn()
+        }
         let hostingController = PlatformHostingController(rootView: ShareView(model: model))
 
         addChild(hostingController)
@@ -46,5 +56,243 @@ final class ShareViewController: PlatformViewController {
         preferredContentSize = preferredExtensionSize
         #endif
         model.loadInitialContent()
+    }
+}
+
+private struct OAuthAuthorizationRequest {
+    let url: URL
+    let codeVerifier: String
+    let state: String
+}
+
+@MainActor
+private final class ShareExtensionGoogleAuthenticator: NSObject, ASWebAuthenticationPresentationContextProviding {
+    private weak var presentingViewController: PlatformViewController?
+    private let decoder = JSONDecoder()
+    private let deliveryService = GmailDeliveryService()
+    private var webAuthenticationSession: ASWebAuthenticationSession?
+
+    init(presentingViewController: PlatformViewController) {
+        self.presentingViewController = presentingViewController
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    func signIn() async throws -> GmailSession {
+        guard GoogleOAuthConfig.isConfigured else {
+            throw GmailAPIError.notConfigured
+        }
+
+        guard presentationAnchor != nil else {
+            throw GmailAPIError.authorizationFailed("Google sign-in could not be presented from the share sheet.")
+        }
+
+        let request = try makeAuthorizationRequest()
+        let callbackURL = try await authenticateWithGoogle(
+            url: request.url,
+            callbackScheme: GoogleOAuthConfig.redirectScheme
+        )
+        guard let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false) else {
+            throw GmailAPIError.invalidRedirect
+        }
+
+        guard components.queryItems?.first(where: { $0.name == "state" })?.value == request.state else {
+            throw GmailAPIError.invalidState
+        }
+
+        if let authorizationError = Self.authorizationError(from: components.queryItems ?? []) {
+            throw authorizationError
+        }
+
+        guard let code = components.queryItems?.first(where: { $0.name == "code" })?.value else {
+            throw GmailAPIError.invalidRedirect
+        }
+
+        let tokenResponse = try await exchangeCodeForTokens(code: code, codeVerifier: request.codeVerifier)
+        guard let refreshToken = tokenResponse.refreshToken else {
+            throw GmailAPIError.missingRefreshToken
+        }
+
+        var session = GmailSession(
+            accessToken: tokenResponse.accessToken,
+            refreshToken: refreshToken,
+            expiryDate: Date().addingTimeInterval(tokenResponse.expiresIn)
+        )
+        let userInfo = try await deliveryService.fetchUserInfo(accessToken: session.accessToken)
+        session.emailAddress = userInfo.email
+        return session
+    }
+
+    private func authenticateWithGoogle(url: URL, callbackScheme: String) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: url,
+                callbackURLScheme: callbackScheme
+            ) { [weak self] callbackURL, error in
+                self?.webAuthenticationSession = nil
+
+                if let callbackURL {
+                    continuation.resume(returning: callbackURL)
+                } else if let error {
+                    let nsError = error as NSError
+                    if nsError.domain == ASWebAuthenticationSessionErrorDomain,
+                       nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
+                        continuation.resume(throwing: GmailAPIError.signInCanceled)
+                    } else {
+                        continuation.resume(throwing: error)
+                    }
+                } else {
+                    continuation.resume(throwing: GmailAPIError.invalidRedirect)
+                }
+            }
+
+            session.prefersEphemeralWebBrowserSession = false
+            session.presentationContextProvider = self
+            self.webAuthenticationSession = session
+
+            guard session.start() else {
+                self.webAuthenticationSession = nil
+                continuation.resume(
+                    throwing: GmailAPIError.authorizationFailed("Google sign-in could not start from the share sheet.")
+                )
+                return
+            }
+        }
+    }
+
+    private func exchangeCodeForTokens(code: String, codeVerifier: String) async throws -> TokenResponse {
+        var request = URLRequest(url: GoogleOAuthConfig.tokenEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = [
+            URLQueryItem(name: "client_id", value: GoogleOAuthConfig.clientID),
+            URLQueryItem(name: "code", value: code),
+            URLQueryItem(name: "code_verifier", value: codeVerifier),
+            URLQueryItem(name: "grant_type", value: "authorization_code"),
+            URLQueryItem(name: "redirect_uri", value: GoogleOAuthConfig.redirectURI)
+        ].percentEncodedQuery?.data(using: .utf8)
+
+        let data = try await send(request)
+        return try decoder.decode(TokenResponse.self, from: data)
+    }
+
+    private func send(_ request: URLRequest) async throws -> Data {
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw GmailAPIError.invalidResponse
+            }
+
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                if let message = Self.extractErrorMessage(from: data) {
+                    throw GmailAPIError.api(message)
+                }
+                throw GmailAPIError.api("Google API returned status \(httpResponse.statusCode).")
+            }
+
+            return data
+        } catch let error as GmailAPIError {
+            throw error
+        } catch {
+            throw GmailAPIError.transport(error)
+        }
+    }
+
+    private func makeAuthorizationRequest() throws -> OAuthAuthorizationRequest {
+        let codeVerifier = Self.randomVerifier()
+        let challenge = Self.codeChallenge(for: codeVerifier)
+        let state = Self.randomState()
+        var components = URLComponents(url: GoogleOAuthConfig.authorizationEndpoint, resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "client_id", value: GoogleOAuthConfig.clientID),
+            URLQueryItem(name: "redirect_uri", value: GoogleOAuthConfig.redirectURI),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: GoogleOAuthConfig.scopes.joined(separator: " ")),
+            URLQueryItem(name: "access_type", value: "offline"),
+            URLQueryItem(name: "prompt", value: "consent"),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: challenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256")
+        ]
+
+        guard let url = components?.url else {
+            throw GmailAPIError.invalidResponse
+        }
+
+        return OAuthAuthorizationRequest(url: url, codeVerifier: codeVerifier, state: state)
+    }
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        guard let presentationAnchor else {
+            preconditionFailure("No presentation anchor available for share-sheet Google sign-in.")
+        }
+
+        return presentationAnchor
+    }
+
+    private var presentationAnchor: ASPresentationAnchor? {
+        #if os(iOS)
+        return presentingViewController?.view.window
+        #elseif os(macOS)
+        return presentingViewController?.view.window
+        #else
+        return nil
+        #endif
+    }
+
+    private static func extractErrorMessage(from data: Data) -> String? {
+        guard
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let error = json["error"] as? [String: Any]
+        else {
+            return nil
+        }
+
+        if let message = error["message"] as? String {
+            return message
+        }
+
+        if let details = error["errors"] as? [[String: Any]],
+           let first = details.first,
+           let message = first["message"] as? String {
+            return message
+        }
+
+        return nil
+    }
+
+    private static func authorizationError(from queryItems: [URLQueryItem]) -> GmailAPIError? {
+        guard let code = queryItems.first(where: { $0.name == "error" })?.value else {
+            return nil
+        }
+
+        let description = queryItems
+            .first(where: { $0.name == "error_description" })?
+            .value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if code == "access_denied" {
+            return .signInCanceled
+        }
+
+        if let description, !description.isEmpty {
+            return .authorizationFailed("Google sign-in failed: \(description)")
+        }
+
+        return .authorizationFailed("Google sign-in failed (\(code)).")
+    }
+
+    private static func randomVerifier() -> String {
+        let charset = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~")
+        return String((0..<64).compactMap { _ in charset.randomElement() })
+    }
+
+    private static func randomState() -> String {
+        let charset = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~")
+        return String((0..<32).compactMap { _ in charset.randomElement() })
+    }
+
+    private static func codeChallenge(for verifier: String) -> String {
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        return Data(digest).base64URLEncodedString()
     }
 }


### PR DESCRIPTION
## Summary
- stop the share sheet from implying auto-send when Gmail is disconnected
- present a Connect Gmail alert and run Google sign-in directly from the share sheet
- document the updated share-sheet Gmail flow in the README and handoff notes

## Testing
- xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO
- xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO

Closes #9