### PR TITLE
Refine missing recipient validation in share sheet

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,7 +4,7 @@ Last updated: March 7, 2026
 
 ## Current State
 
-- Repo: `codex/share-sheet-gmail-signin`
+- Repo: `codex/recipient-helper-focus`
 - Latest intended app version: `0.3`
 - Recent shipped commits:
   - `334a80e` `Separate recipient settings from account`
@@ -54,8 +54,8 @@ Last updated: March 7, 2026
   - iOS startup now includes a short branded splash overlay in addition to the launch storyboard
   - the share extension processing state now says `Auto-Sending...`, keeps `Edit` available for a 0.5-second grace period before auto-send starts, and uses a roomier bordered `Edit` action that still cancels auto-send and returns to the draft without changing the saved preference
   - manual sends now queue first and dismiss the sheet immediately, then continue best-effort preview enrichment and delivery in the background; if that work does not finish, the queued item remains for later retry
-  - if no default recipient is saved, the share extension now shows a specific inline `To` warning and keeps `Send` disabled until a recipient is entered instead of falling back to the generic validation error
   - if Gmail is not connected, the share sheet now stops before auto-send, presents a `Connect Gmail in SendMoi` alert, and can start Google sign-in directly from the share sheet so queued items can resume sending with less ambiguity
+  - if no default recipient is saved, the share extension now starts with a neutral inline helper under `To`, only switches to the red validation copy after a failed send attempt, and refocuses the `To` field so the user can recover immediately
   - refreshed the SendMoi icon source in `marketing/send-moi.icon` and `SendMoi/send-moi.icon`, regenerated every `AppIcon.appiconset` size from the updated 1024 master PNG, and updated marketing icon exports in this repo
 
 ## Things To Verify On The Next Machine
@@ -74,6 +74,7 @@ Last updated: March 7, 2026
 10. Confirm the next Xcode Cloud upload succeeds with build number `3`; the previous failure was `The bundle version must be higher than the previously uploaded version.`
 11. After the next icon refresh, run `./scripts/prune_app_icon_set.sh` and confirm Xcode no longer shows `AppIcon` asset warnings before archiving.
 12. Launch the share sheet while signed out of Gmail and confirm the new connect alert appears, starts Google sign-in from the share sheet itself, and resumes sending without implying that auto-send already happened.
+13. Open the share sheet with no default recipient and confirm the initial helper text feels neutral, then tap `Send` and verify the red validation state appears and the `To` field becomes focused.
 
 ## Local Setup
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The `SendMoiShare` extension is included for iPhone, iPad, and macOS share sheet
 - If Gmail is not connected yet, automatic sending is held back so the share sheet does not imply that delivery is already underway.
 - If you tap `Send`, SendMoi first saves the draft to the queue, dismisses the sheet immediately, and then continues best-effort preview enrichment and delivery in the background. If that background work does not finish, the queued item is retried later.
 - If `Auto-send` is disabled, it stays open and pre-fills the draft so you can review before sending.
-- If no default recipient is saved, the share sheet keeps `Send` disabled, shows an inline `To`-field warning, and asks you to enter a recipient before it will queue or send anything.
+- If no default recipient is saved, the share sheet shows a neutral inline helper under `To`, then promotes that guidance into a red validation message only after you tap `Send` without a recipient; on iPhone and iPad it also returns focus to the `To` field so you can fix it immediately.
 - If immediate delivery fails, it writes the message into the shared queue and exits cleanly.
 - If the host app only supplies a URL, the extension can still fetch metadata and allow manual editing before queueing.
 - Image-only shares from apps like Photos are stored in the shared App Group container, then cleaned up after send or deletion.

--- a/SendMoiShare/ShareExtensionModel.swift
+++ b/SendMoiShare/ShareExtensionModel.swift
@@ -7,6 +7,7 @@ final class ShareExtensionModel: ObservableObject {
     private static let autoSendGracePeriodNanoseconds: UInt64 = 1_000_000_000
     private static let manualSendPreviewWaitLimitNanoseconds: UInt64 = 750_000_000
     static let missingRecipientMessage = "Enter a recipient in the To field, or set a default recipient in the SendMoi app."
+    static let recipientHelperMessage = "Pro tip: add a recipient here, or save a default recipient in the SendMoi app."
     private static let connectGmailStatusMessage = "Connect Gmail to send from the share sheet. You can still queue this share and send it after sign-in."
 
     enum PresentationMode: Equatable {
@@ -14,7 +15,13 @@ final class ShareExtensionModel: ObservableObject {
         case editing
     }
 
-    @Published var toEmail = ""
+    @Published var toEmail = "" {
+        didSet {
+            if !toEmail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                showsMissingRecipientValidation = false
+            }
+        }
+    }
     @Published var title = ""
     @Published var excerpt = ""
     @Published var summary = ""
@@ -29,6 +36,8 @@ final class ShareExtensionModel: ObservableObject {
     @Published var savedRecipients: [String] = []
     @Published var presentationMode: PresentationMode = .processing
     @Published var showsGmailConnectAlert = false
+    @Published private(set) var showsMissingRecipientValidation = false
+    @Published private(set) var recipientFocusRequest = 0
 
     private weak var extensionContextRef: NSExtensionContext?
     private let deliveryService = GmailDeliveryService()
@@ -81,12 +90,18 @@ final class ShareExtensionModel: ObservableObject {
         let draft = currentDraft()
         let shouldAllowAutoSendEditWindow = presentationMode == .processing
 
+        if draft.toEmail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            showsMissingRecipientValidation = true
+            recipientFocusRequest &+= 1
+        }
+
         if let validationMessage = validationMessage(for: draft) {
             statusMessage = validationMessage
             presentationMode = .editing
             return
         }
 
+        showsMissingRecipientValidation = false
         let item = makeQueuedEmail(from: draft)
         let shouldQueueWhilePreviewLoads = isRefreshingPreview && previewTask != nil
         if shouldQueueWhilePreviewLoads && presentationMode == .editing {
@@ -161,13 +176,20 @@ final class ShareExtensionModel: ObservableObject {
         }
     }
 
-    var recipientValidationMessage: String? {
+    var recipientInlineMessage: String? {
         let trimmedRecipient = toEmail.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmedRecipient.isEmpty else {
             return nil
         }
 
-        return Self.missingRecipientMessage
+        return showsMissingRecipientValidation
+            ? Self.missingRecipientMessage
+            : Self.recipientHelperMessage
+    }
+
+    var recipientInlineMessageIsError: Bool {
+        showsMissingRecipientValidation &&
+        toEmail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private func currentDraft() -> ShareDraft {
@@ -230,7 +252,7 @@ final class ShareExtensionModel: ObservableObject {
             statusMessage = Self.connectGmailStatusMessage
             presentationMode = .editing
         } else if toEmail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            statusMessage = Self.missingRecipientMessage
+            statusMessage = "Review and tap Send when ready."
             presentationMode = .editing
         } else if autoSendEnabled {
             statusMessage = "Auto-Sending..."
@@ -257,7 +279,7 @@ final class ShareExtensionModel: ObservableObject {
         }
 
         if draft.toEmail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            statusMessage = Self.missingRecipientMessage
+            statusMessage = "Review and tap Send when ready."
             presentationMode = .editing
             return
         }

--- a/SendMoiShare/ShareView.swift
+++ b/SendMoiShare/ShareView.swift
@@ -2,6 +2,11 @@ import SwiftUI
 
 struct ShareView: View {
     @ObservedObject var model: ShareExtensionModel
+    @FocusState private var focusedField: Field?
+
+    private enum Field: Hashable {
+        case recipient
+    }
 
     var body: some View {
         NavigationStack {
@@ -23,6 +28,10 @@ struct ShareView: View {
                 }
             }
             .navigationTitle("SendMoi")
+            .onChange(of: model.recipientFocusRequest) { _, request in
+                guard request > 0 else { return }
+                focusedField = .recipient
+            }
             .onChange(of: model.urlString) { _, _ in
                 model.schedulePreviewRefresh()
             }
@@ -72,16 +81,18 @@ struct ShareView: View {
                         .foregroundStyle(.secondary)
                     #if os(iOS)
                     TextField("Email address", text: $model.toEmail)
+                        .focused($focusedField, equals: .recipient)
                         .textInputAutocapitalization(.never)
                         .keyboardType(.emailAddress)
                         .autocorrectionDisabled()
                     #else
                     TextField("Email address", text: $model.toEmail)
+                        .focused($focusedField, equals: .recipient)
                     #endif
-                    if let recipientValidationMessage = model.recipientValidationMessage {
-                        Text(recipientValidationMessage)
+                    if let recipientInlineMessage = model.recipientInlineMessage {
+                        Text(recipientInlineMessage)
                             .font(.caption2)
-                            .foregroundStyle(.red)
+                            .foregroundStyle(model.recipientInlineMessageIsError ? .red : .secondary)
                     }
                     if !recentRecipientSuggestions.isEmpty {
                         recentRecipientsView
@@ -400,7 +411,7 @@ struct ShareView: View {
             return false
         }
 
-        if model.statusMessage == model.recipientValidationMessage {
+        if model.statusMessage == model.recipientInlineMessage {
             return false
         }
 
@@ -426,7 +437,8 @@ struct ShareView: View {
     }
 
     private var sendButtonDisabled: Bool {
-        model.presentationMode != .editing || model.isSaving || model.isConnectingGmail || model.recipientValidationMessage != nil
+        model.presentationMode != .editing || model.isSaving
+            || model.isConnectingGmail
     }
 
     private var overlayBorderColor: Color {


### PR DESCRIPTION
## Summary
- replace the immediate red missing-recipient warning with neutral helper text
- only show the red validation state after tapping Send with no recipient
- focus the To field on validation failure so iPhone and iPad bring the keyboard back immediately

## Testing
- xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO
- xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO

Closes #11