### PR TITLE
Fix iOS startup splash icon mismatch

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -51,7 +51,7 @@ Last updated: March 7, 2026
   - low-quality summaries are filtered more aggressively, and summaries are skipped for X/Twitter and Overcast sources
   - `scripts/prune_app_icon_set.sh` now removes undeclared files from `AppIcon.appiconset` after icon refreshes so Xcode does not report `AppIcon` unassigned-child warnings from stray exported PNGs
   - the restored `desktopComposeCard` keeps the macOS compose panel buildable again after the helper was accidentally dropped from `ContentView.swift`, while preserving the current share-sheet-only drafting flow
-  - iOS startup now includes a short branded splash overlay in addition to the launch storyboard
+  - iOS startup now relies on `LaunchScreen.storyboard` only; the extra in-app splash overlay was removed so the startup mark matches the launch asset instead of rendering an SF Symbol paper plane
   - the share extension processing state now says `Auto-Sending...`, keeps `Edit` available for a 0.5-second grace period before auto-send starts, and uses a roomier bordered `Edit` action that still cancels auto-send and returns to the draft without changing the saved preference
   - manual sends now queue first and dismiss the sheet immediately, then continue best-effort preview enrichment and delivery in the background; if that work does not finish, the queued item remains for later retry
   - if Gmail is not connected, the share sheet now stops before auto-send, presents a `Connect Gmail in SendMoi` alert, and can start Google sign-in directly from the share sheet so queued items can resume sending with less ambiguity

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ SendMoi currently ships the full core workflow:
 - Retry queued emails when the app launches, becomes active, or connectivity returns.
 - Share queue state, saved recipients, and session data through the App Group `group.com.niederme.mailmoi`.
 - Let the share sheet either send immediately or stay open with a pre-filled draft, based on the global `Auto-send` setting in the app.
+- Use the iOS launch storyboard branding directly at startup, without an extra in-app splash overlay.
 - Use a settings-style form on iPhone and iPad, and a desktop card layout on macOS.
 - Show a branded first-run setup guide with step-by-step onboarding, Gmail connect/switch, and a final “ready” step that can save recipient defaults before entering settings.
 - Let users reopen setup from the app and run a destructive reset flow that disconnects Gmail and clears saved setup preferences.

--- a/SendMoi/SendMoiApp.swift
+++ b/SendMoi/SendMoiApp.swift
@@ -4,34 +4,13 @@ import SwiftUI
 struct SendMoiApp: App {
     @StateObject private var model = AppModel()
     @Environment(\.scenePhase) private var scenePhase
-    @State private var showsSplashOverlay = true
 
     var body: some Scene {
         WindowGroup {
-            ZStack {
-                ContentView()
-                    .environmentObject(model)
-
-                #if os(iOS)
-                if showsSplashOverlay {
-                    SplashOverlayView()
-                        .transition(.opacity)
-                }
-                #endif
-            }
+            ContentView()
+                .environmentObject(model)
             .task {
-                async let startup: Void = model.startup()
-
-                #if os(iOS)
-                try? await Task.sleep(for: .milliseconds(650))
-                if !Task.isCancelled {
-                    withAnimation(.easeOut(duration: 0.2)) {
-                        showsSplashOverlay = false
-                    }
-                }
-                #endif
-
-                _ = await startup
+                await model.startup()
             }
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -43,39 +22,3 @@ struct SendMoiApp: App {
         }
     }
 }
-
-#if os(iOS)
-private struct SplashOverlayView: View {
-    var body: some View {
-        GeometryReader { proxy in
-            let splashSize = min(max(proxy.size.width * 0.34, 120), 180)
-
-            ZStack {
-                LinearGradient(
-                    colors: [
-                        Color(red: 0.22, green: 0.49, blue: 0.98),
-                        Color(red: 0.10, green: 0.34, blue: 0.96),
-                        Color(red: 0.69, green: 0.09, blue: 0.99)
-                    ],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-
-                VStack(spacing: splashSize * 0.16) {
-                    Image(systemName: "paperplane.fill")
-                        .font(.system(size: splashSize, weight: .regular))
-                        .rotationEffect(.degrees(18))
-                        .foregroundStyle(.white)
-
-                    Text("moi")
-                        .font(.system(size: splashSize * 0.56, weight: .bold, design: .rounded))
-                        .foregroundStyle(.white)
-                }
-                .offset(y: -proxy.size.height * 0.03)
-            }
-            .ignoresSafeArea()
-        }
-        .accessibilityHidden(true)
-    }
-}
-#endif


### PR DESCRIPTION
## Summary
- remove the extra in-app iOS splash overlay from SendMoiApp.swift
- rely on LaunchScreen.storyboard branding only at startup
- update README and HANDOFF notes to reflect launch-screen-only startup branding

## Why
The in-app overlay rendered an SF Symbol paper plane (paperplane.fill) that did not match the launch asset, causing the wrong startup mark to appear.

Closes #13

## Validation
- attempted CLI build check, but this machine is set to Command Line Tools only (xcodebuild requires full Xcode path)
- runtime verification should be done in Xcode/simulator on this machine