### PR TITLE
Allow summaries for concise high-quality pages

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,7 +4,7 @@ Last updated: March 7, 2026
 
 ## Current State
 
-- Repo: `codex/recipient-helper-focus`
+- Repo: `codex/summary-for-short-pages`
 - Latest intended app version: `0.3`
 - Recent shipped commits:
   - `334a80e` `Separate recipient settings from account`
@@ -28,6 +28,7 @@ Last updated: March 7, 2026
   - summary preamble cleanup was added
   - preview image and summary handling were improved
   - summary length now scales with extracted page text length so shorter pages get shorter blurbs instead of forcing article-sized summaries
+  - summary generation now accepts concise but substantive pages (70+ cleaned words), so profile/home pages can still produce a 1-2 sentence recap
 - Added:
   - `PRIVACY.md`
   - `TERMS.md`
@@ -75,6 +76,7 @@ Last updated: March 7, 2026
 11. After the next icon refresh, run `./scripts/prune_app_icon_set.sh` and confirm Xcode no longer shows `AppIcon` asset warnings before archiving.
 12. Launch the share sheet while signed out of Gmail and confirm the new connect alert appears, starts Google sign-in from the share sheet itself, and resumes sending without implying that auto-send already happened.
 13. Open the share sheet with no default recipient and confirm the initial helper text feels neutral, then tap `Send` and verify the red validation state appears and the `To` field becomes focused.
+14. Share `https://www.francescabond.com/` (or a similar profile/home page with limited body text) and confirm the preview keeps the OG image while now showing a short summary instead of omitting it.
 
 ## Local Setup
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For reachable web URLs, SendMoi attempts to enrich the message before sending:
 
 - Uses the page `<title>` when available, with sensible metadata fallbacks.
 - Pulls a page description when one is available.
-- Generates a short summary when enough high-quality body content is available, sizing the blurb to the amount of source text instead of always forcing an article-length recap.
+- Generates a short summary when enough high-quality body content is available (including shorter profile/home pages, not just long articles), sizing the blurb to the amount of source text instead of always forcing an article-length recap.
 - Inlines a preview image when the page exposes one and the image fetch succeeds.
 - Renders the HTML email as a responsive card layout for desktop and mobile clients.
 - Normalizes common shared-post formats, including X/Twitter share text and Overcast titles, before building the email.

--- a/SendMoi/Services/GmailDeliveryService.swift
+++ b/SendMoi/Services/GmailDeliveryService.swift
@@ -1694,7 +1694,9 @@ final class GmailDeliveryService {
         }
 
         let cleanedText = normalizeArticleText(plainText, title: title, excerpt: excerpt)
-        guard wordCount(in: cleanedText) > 100,
+        // Allow concise homepage/profile content to be summarized when it still has
+        // meaningful body text, while relying on existing quality gates to reject noise.
+        guard wordCount(in: cleanedText) >= 70,
               passesSummaryInputQualityGate(cleanedText, title: title) else {
             return nil
         }


### PR DESCRIPTION
## Summary
- lower summary generation floor from 100 to 70 cleaned words for high-quality page text
- keep existing input/output quality gates in place to avoid noisy summaries
- update README and HANDOFF notes to reflect concise-page summary behavior

## Why
Homepage/profile links can contain meaningful content but still fall under the previous 100-word threshold, causing no summary even when a short recap would be useful.

Closes #15

## Validation
- attempted CLI validation with xcodebuild, but this machine is configured to Command Line Tools only and does not have full Xcode selected
- verified extracted content for a concise profile/homepage page is below the previous threshold