### PR TITLE
Fix false-positive promo filtering that drops concise page summaries

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,7 +4,7 @@ Last updated: March 7, 2026
 
 ## Current State
 
-- Repo: `codex/summary-for-short-pages`
+- Repo: `codex/fix-summary-promo-filter`
 - Latest intended app version: `0.3`
 - Recent shipped commits:
   - `334a80e` `Separate recipient settings from account`
@@ -29,6 +29,7 @@ Last updated: March 7, 2026
   - preview image and summary handling were improved
   - summary length now scales with extracted page text length so shorter pages get shorter blurbs instead of forcing article-sized summaries
   - summary generation now accepts concise but substantive pages (70+ cleaned words), so profile/home pages can still produce a 1-2 sentence recap
+  - summary promo filtering now treats newsletter mentions as promo only for short CTA-style lines, so substantive profile/homepage content is not dropped from summary input
 - Added:
   - `PRIVACY.md`
   - `TERMS.md`
@@ -76,7 +77,7 @@ Last updated: March 7, 2026
 11. After the next icon refresh, run `./scripts/prune_app_icon_set.sh` and confirm Xcode no longer shows `AppIcon` asset warnings before archiving.
 12. Launch the share sheet while signed out of Gmail and confirm the new connect alert appears, starts Google sign-in from the share sheet itself, and resumes sending without implying that auto-send already happened.
 13. Open the share sheet with no default recipient and confirm the initial helper text feels neutral, then tap `Send` and verify the red validation state appears and the `To` field becomes focused.
-14. Share `https://www.francescabond.com/` (or a similar profile/home page with limited body text) and confirm the preview keeps the OG image while now showing a short summary instead of omitting it.
+14. Share a concise profile/homepage URL that includes a newsletter mention in body copy and confirm SendMoi still generates a short summary when the page has meaningful text.
 
 ## Local Setup
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ For reachable web URLs, SendMoi attempts to enrich the message before sending:
 
 - Uses the page `<title>` when available, with sensible metadata fallbacks.
 - Pulls a page description when one is available.
-- Generates a short summary when enough high-quality body content is available (including shorter profile/home pages, not just long articles), sizing the blurb to the amount of source text instead of always forcing an article-length recap.
+- Generates a short summary when enough high-quality body content is available (including concise profile/home pages), sizing the blurb to the amount of source text instead of always forcing an article-length recap.
+- Keeps promo filtering strict for obvious CTA fragments while avoiding false positives that can drop substantive profile/homepage lines.
 - Inlines a preview image when the page exposes one and the image fetch succeeds.
 - Renders the HTML email as a responsive card layout for desktop and mobile clients.
 - Normalizes common shared-post formats, including X/Twitter share text and Overcast titles, before building the email.

--- a/SendMoi/Services/GmailDeliveryService.swift
+++ b/SendMoi/Services/GmailDeliveryService.swift
@@ -1946,7 +1946,6 @@ final class GmailDeliveryService {
         let directMarkers = [
             "sign up",
             "the latest",
-            "newsletter",
             "horoscope",
             "horoscopes",
             "podcast by",
@@ -1961,6 +1960,16 @@ final class GmailDeliveryService {
         }
 
         let headlineLikeWords = line.split(whereSeparator: \.isWhitespace)
+
+        // Treat newsletter mentions as promo only when they are short CTA-style copy.
+        if lowered.contains("newsletter"),
+           headlineLikeWords.count <= 18,
+           (lowered.contains("sign up") ||
+            lowered.contains("subscribe") ||
+            lowered.contains("join")) {
+            return true
+        }
+
         let hasDateToken = lowered.range(of: #"\b\d{1,2}/\d{1,2}/\d{2,4}\b"#, options: .regularExpression) != nil
         let hasTimeToken = lowered.range(of: #"\b\d{1,2}:\d{2}\s*[ap]\.m\.\b"#, options: .regularExpression) != nil
 


### PR DESCRIPTION
## Summary
- refine summary promo-line detection so newsletter mentions are only treated as promo in short CTA-style lines
- preserve substantive profile/homepage content that references newsletters in normal prose
- update README and HANDOFF to document the refined summary-filter behavior

## Why
Issue #17 reports that some concise profile/homepage links still render without a summary. The previous heuristic dropped any line containing newsletter, which could remove most or all useful body text for concise pages.

Closes #17

## Validation
- static code inspection of the summary pipeline and heuristic behavior
- CLI build/test validation not run in this environment (Command Line Tools only, no full Xcode toolchain)