### PR TITLE
Sync auto-send docs to 1-second grace period

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,6 @@
 # SendMoi Handoff
 
-Last updated: March 7, 2026
+Last updated: March 9, 2026
 
 ## Current State
 
@@ -62,7 +62,7 @@ Last updated: March 7, 2026
   - `scripts/prune_app_icon_set.sh` now removes undeclared files from `AppIcon.appiconset` after icon refreshes so Xcode does not report `AppIcon` unassigned-child warnings from stray exported PNGs
   - the restored `desktopComposeCard` keeps the macOS compose panel buildable again after the helper was accidentally dropped from `ContentView.swift`, while preserving the current share-sheet-only drafting flow
   - iOS startup now relies on `LaunchScreen.storyboard` only; the extra in-app splash overlay was removed so the startup mark matches the launch asset instead of rendering an SF Symbol paper plane
-  - the share extension processing state now says `Auto-Sending...`, keeps `Edit` available for a 0.5-second grace period before auto-send starts, and uses a roomier bordered `Edit` action that still cancels auto-send and returns to the draft without changing the saved preference
+  - the share extension processing state now says `Auto-Sending...`, keeps `Edit` available for a 1-second grace period before auto-send starts, and uses a roomier bordered `Edit` action that still cancels auto-send and returns to the draft without changing the saved preference
   - manual sends now queue first and dismiss the sheet immediately, then continue best-effort preview enrichment and delivery in the background; if that work does not finish, the queued item remains for later retry
   - if Gmail is not connected, the share sheet now stops before auto-send, presents a `Connect Gmail in SendMoi` alert, and can start Google sign-in directly from the share sheet so queued items can resume sending with less ambiguity
   - if no default recipient is saved, the share extension now starts with a neutral inline helper under `To`, only switches to the red validation copy after a failed send attempt, and refocuses the `To` field so the user can recover immediately

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ The `SendMoiShare` extension is included for iPhone, iPad, and macOS share sheet
 - It reads the title, description, URL, and first shared image from the shared item when the host app provides them.
 - For X/Twitter shares, it can rewrite noisy shared text into a cleaner draft and canonicalize tweet URLs before fetching preview metadata.
 - If Gmail is not connected, the share sheet shows a `Connect Gmail in SendMoi` alert and can start the Google sign-in flow directly from the share sheet.
-- If `Auto-send` is enabled and a default recipient is already saved, it waits 0.5 seconds after the draft is ready, then tries to send automatically.
-- While auto-send is in progress, the sheet shows an `Auto-Sending...` state with a secondary `Edit` action that stays available during that 0.5-second grace period and still cancels the in-flight auto-send attempt without changing the saved `Auto-send` preference.
+- If `Auto-send` is enabled and a default recipient is already saved, it waits 1 second after the draft is ready, then tries to send automatically.
+- While auto-send is in progress, the sheet shows an `Auto-Sending...` state with a secondary `Edit` action that stays available during that 1-second grace period and still cancels the in-flight auto-send attempt without changing the saved `Auto-send` preference.
 - If Gmail is not connected yet, automatic sending is held back so the share sheet does not imply that delivery is already underway.
 - If you tap `Send`, SendMoi first saves the draft to the queue, dismisses the sheet immediately, and then continues best-effort preview enrichment and delivery in the background. If that background work does not finish, the queued item is retried later.
 - If `Auto-send` is disabled, it stays open and pre-fills the draft so you can review before sending.


### PR DESCRIPTION
## Summary\n- update share extension docs in README to reflect a 1-second auto-send grace period\n- update HANDOFF note for the same 1-second timing\n- leave runtime code unchanged (it is already 1 second)\n\n## Testing\n- not run (docs-only change)