### PR TITLE
Onboarding: normalize compact typography and spacing

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,14 +4,14 @@ Last updated: March 9, 2026
 
 ## Current State
 
-- Repo: `codex/reel-visual-fallback`
+- Repo: `codex/onboarding-typography-parity`
 - Latest intended app version: `0.3`
 - Recent shipped commits:
   - `0e5a871` `Fix summary promo filtering for concise homepage copy (#18)`
   - `0488709` `Allow summaries for concise high-quality pages (#16)`
   - `a7e22c8` `Remove in-app splash overlay to fix wrong startup paper plane (#14)`
 - Current PR focus:
-  - `#23` onboarding polish: switch onboarding actions to native system glass controls (`.glass` / `.glassProminent`) with older-OS fallbacks, while preserving the updated step-3 CTA/nav behavior.
+  - `#24` onboarding typography pass: normalize cross-step headline/subhead scale and spacing, and ensure compact iPhone sizing applies consistently beyond step 1.
 
 ## Quick Resume On Another Mac
 
@@ -47,6 +47,7 @@ Last updated: March 9, 2026
 - `README.md` now reflects current behavior instead of hardcoding the old `0.1` release framing.
 - `AGENTS.md` now treats `BUG:` and `ISSUE:` as the explicit GitHub issue creation prefixes.
 - The onboarding footer now leaves `Skip` on its own and groups `Back` with the trailing primary action.
+- Onboarding compact-layout detection is now device-based (not step-1-only), so step 2/3 typography, card spacing, and bottom inset scale correctly on smaller iPhones.
 - iOS deployment target is now `18.0` for both `SendMoi` and `SendMoiShare`; Foundation Models summary support remains optional at runtime and falls back on unsupported OS versions.
 - New in the current working tree:
   - repo-wide rename from MailMoi to SendMoi: project, targets, schemes, folders, and user-facing copy

--- a/SendMoi/ContentView.swift
+++ b/SendMoi/ContentView.swift
@@ -449,7 +449,10 @@ struct ContentView: View {
         if model.session == nil {
             VStack(alignment: .leading, spacing: 14) {
                 Text("Connect Gmail to finish setup.")
-                    .font(.system(size: 24, weight: .semibold))
+                    .font(.system(size: onboardingFirstStepHeadlineFontSize, weight: .bold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.86)
 
                 onboardingFeatureRow(
                     iconName: "lock.shield.fill",
@@ -474,11 +477,15 @@ struct ContentView: View {
         } else {
             VStack(alignment: .leading, spacing: 16) {
                 Text("Ready to go.")
-                    .font(.system(size: 24, weight: .semibold))
+                    .font(.system(size: onboardingFirstStepHeadlineFontSize, weight: .bold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.86)
 
                 Text("Gmail is connected. Add a default recipient now, or leave it blank and choose in the share sheet each time.")
-                    .font(.footnote)
+                    .font(.system(size: onboardingFirstStepSubheadingFontSize, weight: .medium))
                     .foregroundStyle(.secondary)
+                    .lineSpacing(1.3)
 
                 VStack(alignment: .leading, spacing: 10) {
                     Text("Connected Gmail")
@@ -679,11 +686,13 @@ struct ContentView: View {
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
-                    .font(.headline)
+                    .font(.system(size: onboardingFeatureTitleFontSize, weight: .semibold))
+                    .foregroundStyle(.primary)
 
                 Text(detail)
-                    .font(.footnote)
+                    .font(.system(size: onboardingFeatureDetailFontSize, weight: .medium))
                     .foregroundStyle(.secondary)
+                    .lineSpacing(1.2)
             }
 
             Spacer(minLength: 0)
@@ -843,26 +852,29 @@ struct ContentView: View {
 
     private var onboardingUsesSmallPhoneLayout: Bool {
         #if os(iOS)
-        onboardingUsesTightFirstStepLayout && UIScreen.main.bounds.height <= 812
+        !usesDesktopLayout && UIScreen.main.bounds.height <= 812
         #else
         false
         #endif
     }
 
     private var onboardingMainSpacing: CGFloat {
-        onboardingUsesTightFirstStepLayout ? 16 : 24
+        if onboardingUsesSmallPhoneLayout {
+            return 14
+        }
+        return onboardingUsesTightFirstStepLayout ? 16 : 24
     }
 
     private var onboardingVerticalPadding: CGFloat {
-        onboardingUsesTightFirstStepLayout ? 14 : 24
+        onboardingUsesSmallPhoneLayout ? 12 : (onboardingUsesTightFirstStepLayout ? 14 : 24)
     }
 
     private var onboardingStepCardPadding: CGFloat {
-        onboardingUsesTightFirstStepLayout ? 18 : 22
+        onboardingUsesSmallPhoneLayout ? 16 : (onboardingUsesTightFirstStepLayout ? 18 : 22)
     }
 
     private var onboardingStepCardCornerRadius: CGFloat {
-        onboardingUsesTightFirstStepLayout ? 24 : 28
+        onboardingUsesSmallPhoneLayout ? 22 : (onboardingUsesTightFirstStepLayout ? 24 : 28)
     }
 
     private var onboardingFirstStepSpacing: CGFloat {
@@ -921,7 +933,15 @@ struct ContentView: View {
     }
 
     private var onboardingPinnedActionsInset: CGFloat {
-        110
+        onboardingUsesSmallPhoneLayout ? 102 : 110
+    }
+
+    private var onboardingFeatureTitleFontSize: CGFloat {
+        onboardingUsesSmallPhoneLayout ? 16 : 18
+    }
+
+    private var onboardingFeatureDetailFontSize: CGFloat {
+        onboardingUsesSmallPhoneLayout ? 15 : 16
     }
 
     private var onboardingPinnedActions: some View {


### PR DESCRIPTION
## Summary
- fix compact-layout detection so smaller iPhones use compact onboarding sizing on all steps (not only step 1)
- align final-step headline/subhead and feature-row typography with step-1 visual hierarchy
- scale onboarding card spacing, corner radius, and pinned-action inset for compact devices to preserve relative layout

## Issue
Closes #24

## Notes
- no build checks run in this pass
