### PR TITLE
Fix AppIcon source path and background parity

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -54,7 +54,7 @@ Last updated: March 9, 2026
   - bundle identifiers, App Group ID, and shared container/keychain storage identifiers intentionally remain on the existing MailMoi values for upgrade continuity
   - added a first-pass `TERMS.md` so the Google OAuth consent screen can point at a public Terms of Service URL alongside the existing privacy policy
   - `MARKETING_VERSION` is now `0.3` and `CURRENT_PROJECT_VERSION` is now `6` for both targets, set via `./scripts/prepare_release.sh --version 0.3`
-  - the legacy `CFBundleIconFile` override was removed, and the main app now ships from the explicit `AppIcon.appiconset` while keeping `send-moi.icon` as the editable design source
+  - the legacy `CFBundleIconFile` override was removed, and the main app now ships from the explicit `AppIcon.appiconset` while keeping `AppIcon.icon` as the editable design source
   - `scripts/prepare_release.sh` now bumps version/build across both targets and prints the signing + bundle settings before an archive
   - the macOS app now uses a desktop-style card layout instead of reusing the iPhone/iPad form
   - image-only shares are first-class queue items, with fallback titles like `Shared Photo`
@@ -70,7 +70,8 @@ Last updated: March 9, 2026
   - manual sends now queue first and dismiss the sheet immediately, then continue best-effort preview enrichment and delivery in the background; if that work does not finish, the queued item remains for later retry
   - if Gmail is not connected, the share sheet now stops before auto-send, presents a `Connect Gmail in SendMoi` alert, and can start Google sign-in directly from the share sheet so queued items can resume sending with less ambiguity
   - if no default recipient is saved, the share extension now starts with a neutral inline helper under `To`, only switches to the red validation copy after a failed send attempt, and refocuses the `To` field so the user can recover immediately
-  - refreshed the SendMoi icon source in `marketing/send-moi.icon` and `SendMoi/send-moi.icon`, regenerated every `AppIcon.appiconset` size from the updated 1024 master PNG, and updated marketing icon exports in this repo
+  - refreshed the SendMoi icon source in `marketing/send-moi.icon` and `SendMoi/AppIcon.icon`, regenerated every `AppIcon.appiconset` size from the updated 1024 master PNG, and updated marketing icon exports in this repo
+  - fixed issue #28 by repointing the Xcode icon-source reference to `SendMoi/AppIcon.icon` and restoring `AppIconBackground` light/dark parity while the same color is intentionally used in both appearances
 
 ## Things To Verify On The Next Machine
 
@@ -84,7 +85,7 @@ Last updated: March 9, 2026
 6. Share a photo directly from Photos (without a URL) and confirm it can be queued, sent, and removed without leaving orphaned files in the App Group container.
 7. Share an X/Twitter post and an Overcast episode and confirm the title / source URL / summary behavior looks intentional rather than noisy.
 8. Run the macOS target and confirm the desktop card layout feels right at common window sizes, especially queue deletion and account disclosure behavior.
-9. Run `./scripts/prepare_release.sh --version <next-version>` before the next archive, then verify App Store Connect accepts the `AppIcon` set for both iOS and macOS, shows the expected branded thumbnail, and no longer includes `send-moi.icon` as an extra bundled resource.
+9. Run `./scripts/prepare_release.sh --version <next-version>` before the next archive, then verify App Store Connect accepts the `AppIcon` set for both iOS and macOS, shows the expected branded thumbnail, and no longer includes `AppIcon.icon` as an extra bundled resource.
 10. Confirm the next Xcode Cloud upload succeeds with build number `3`; the previous failure was `The bundle version must be higher than the previously uploaded version.`
 11. After the next icon refresh, run `./scripts/prune_app_icon_set.sh` and confirm Xcode no longer shows `AppIcon` asset warnings before archiving.
 12. Launch the share sheet while signed out of Gmail and confirm the new connect alert appears, starts Google sign-in from the share sheet itself, and resumes sending without implying that auto-send already happened.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The current build is set up to ship through TestFlight.
 - Xcode Cloud is configured to start on pushes to `main`.
 - The active workflow archives both iOS and macOS builds.
 - Successful archives are prepared for `TestFlight (Internal Testing Only)`.
-- The project keeps the branded `send-moi.icon` file as the editable design source, while shipping builds use the checked-in `AppIcon.appiconset` so iPhone, iPad, and macOS all share the same explicit asset-catalog icon path.
+- The project keeps the branded `AppIcon.icon` file as the editable design source, while shipping builds use the checked-in `AppIcon.appiconset` so iPhone, iPad, and macOS all share the same explicit asset-catalog icon path.
 
 When refreshing the icon set from the branded source, run `./scripts/prune_app_icon_set.sh` after copying regenerated PNGs into `SendMoi/Assets.xcassets/AppIcon.appiconset`. That removes any files that are not declared in `Contents.json`, which prevents Xcode's `AppIcon has an unassigned child` warning if an export drops in an extra 1024x1024 PNG.
 

--- a/SendMoi.xcodeproj/project.pbxproj
+++ b/SendMoi.xcodeproj/project.pbxproj
@@ -91,7 +91,7 @@
 		B20000010000000000000005 /* SendMoiShare.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SendMoiShare.entitlements; sourceTree = "<group>"; };
 		B20000010000000000000006 /* SafariPreprocessor.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = SafariPreprocessor.js; sourceTree = "<group>"; };
 		B20000010000000000000007 /* SendMoiShare-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "SendMoiShare-macOS.entitlements"; sourceTree = "<group>"; };
-		DC6FF07A2F55D5CB00415EAC /* send-moi.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = "send-moi.icon"; sourceTree = "<group>"; };
+		DC6FF07A2F55D5CB00415EAC /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = "AppIcon.icon"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,7 +133,7 @@
 				A20000010000000000000002 /* ContentView.swift */,
 				A20000010000000000000003 /* AppModel.swift */,
 				A20000010000000000000004 /* Models.swift */,
-				DC6FF07A2F55D5CB00415EAC /* send-moi.icon */,
+				DC6FF07A2F55D5CB00415EAC /* AppIcon.icon */,
 				A40000010000000000000004 /* Services */,
 			);
 			path = SendMoi;

--- a/SendMoi/Assets.xcassets/AppIconBackground.colorset/Contents.json
+++ b/SendMoi/Assets.xcassets/AppIconBackground.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.984",
-          "green" : "0.412",
-          "red" : "0.122"
+          "blue" : "1.000",
+          "green" : "0.498",
+          "red" : "0.169"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
## Summary
- repoint the Xcode icon source reference to `AppIcon.icon`
- keep `AppIconBackground` light and dark values identical for now
- refresh README/HANDOFF references so docs match the current icon source name

Closes #28

## Testing
- not run (asset/project-config change only)