### PR TITLE
Onboarding step 3: clarify CTA and navigation semantics

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,14 +4,14 @@ Last updated: March 9, 2026
 
 ## Current State
 
-- Repo: `codex/onboarding-typography-parity`
+- Repo: `codex/onboarding-step3-cta-nav`
 - Latest intended app version: `0.3`
 - Recent shipped commits:
   - `0e5a871` `Fix summary promo filtering for concise homepage copy (#18)`
   - `0488709` `Allow summaries for concise high-quality pages (#16)`
   - `a7e22c8` `Remove in-app splash overlay to fix wrong startup paper plane (#14)`
 - Current PR focus:
-  - `#24` onboarding typography pass: normalize cross-step headline/subhead scale and spacing, and ensure compact iPhone sizing applies consistently beyond step 1.
+  - `#26` onboarding step-3 semantics: align signed-out CTA behavior with bottom navigation semantics and make disabled-next state clearly intentional.
 
 ## Quick Resume On Another Mac
 
@@ -48,6 +48,7 @@ Last updated: March 9, 2026
 - `AGENTS.md` now treats `BUG:` and `ISSUE:` as the explicit GitHub issue creation prefixes.
 - The onboarding footer now leaves `Skip` on its own and groups `Back` with the trailing primary action.
 - Onboarding compact-layout detection is now device-based (not step-1-only), so step 2/3 typography, card spacing, and bottom inset scale correctly on smaller iPhones.
+- Onboarding step 3 now uses a clearly-disabled lock-style trailing nav control when Gmail is disconnected, keeps `Connect Gmail` as the in-card primary action, and adds helper copy that clarifies users can still skip and connect later.
 - iOS deployment target is now `18.0` for both `SendMoi` and `SendMoiShare`; Foundation Models summary support remains optional at runtime and falls back on unsupported OS versions.
 - New in the current working tree:
   - repo-wide rename from MailMoi to SendMoi: project, targets, schemes, folders, and user-facing copy

--- a/SendMoi/ContentView.swift
+++ b/SendMoi/ContentView.swift
@@ -280,13 +280,15 @@ struct ContentView: View {
                     } else if onboardingStep == 2 && model.session == nil {
                         Button {
                         } label: {
-                            Image(systemName: "chevron.right")
+                            Image(systemName: "lock.fill")
                         }
-                        .onboardingPrimaryButtonStyle(tint: onboardingBrandAccent)
+                        .onboardingSecondaryButtonStyle()
                         .buttonBorderShape(.circle)
                         .controlSize(.large)
                         .frame(width: 46, height: 46)
                         .disabled(true)
+                        .accessibilityLabel("Next unavailable")
+                        .accessibilityHint("Connect Gmail with the button above, or tap Skip.")
                     }
                 }
             }
@@ -468,11 +470,15 @@ struct ContentView: View {
                 Button("Connect Gmail") {
                     showsOnboardingAccountSheet = true
                 }
-                .onboardingPrimaryButtonStyle(tint: onboardingBrandAccent)
-                .buttonBorderShape(.capsule)
+                .buttonStyle(.borderedProminent)
                 .controlSize(.large)
                 .disabled(!GoogleOAuthConfig.isConfigured)
                 .padding(.top, 4)
+                .accessibilityHint("Opens Google sign-in in a system sheet.")
+
+                Text("Or tap Skip below and connect later from Account.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
         } else {
             VStack(alignment: .leading, spacing: 16) {
@@ -508,8 +514,8 @@ struct ContentView: View {
                         Button("Switch Account") {
                             showsOnboardingAccountSheet = true
                         }
-                        .buttonStyle(.plain)
-                        .foregroundStyle(onboardingBrandAccent)
+                        .buttonStyle(.bordered)
+                        .controlSize(.regular)
                     }
                     .padding(.horizontal, 14)
                     .padding(.vertical, 12)


### PR DESCRIPTION
## Summary
- keep signed-out step 3 focused on the in-card Connect Gmail CTA while making trailing nav state explicitly unavailable
- replace disabled right-chevron with a disabled lock-style control plus accessibility context
- align step-3 action treatment closer to account patterns (Connect Gmail as prominent control, Switch Account as bordered control)
- add helper copy clarifying users can still skip onboarding and connect later from Account

## Issue
Closes #26

## Notes
- no build checks run in this pass