### PR TITLE
Bump HANDOFF date to verify Xcode Cloud workflow

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,6 @@
 # SendMoi Handoff
 
-Last updated: March 10, 2026
+Last updated: March 11, 2026
 
 ## Current State
 


### PR DESCRIPTION
Trivial change to test that Xcode Cloud now routes builds to the correct SendMoi app record after the workflow and bundle ID fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)