### PR TITLE
Prevent onboarding demo video from stealing audio focus

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -48,6 +48,7 @@ Last updated: March 11, 2026
 - Onboarding compact-layout detection is now device-based (not step-1-only), so step 2/3 typography, card spacing, and bottom inset scale correctly on smaller iPhones.
 - Onboarding step 2 now adds `Step x of 3` progress text, tappable pagination dots, compact-phone image padding tuning, and explicit accessibility labels/hints for each slide.
 - Onboarding step 3 now uses a clearly-disabled `chevron.right` trailing nav control when Gmail is disconnected, keeps `Connect Gmail` as the in-card primary action, and adds helper copy that clarifies users can still skip and connect later.
+- The onboarding hero demo now builds a video-only playback item so it stays silent and no longer steals audio focus from background audio.
 - iOS deployment target is now `18.0` for both `SendMoi` and `SendMoiShare`; Foundation Models summary support remains optional at runtime and falls back on unsupported OS versions.
 - New in the current working tree:
   - repo-wide rename from MailMoi to SendMoi: project, targets, schemes, folders, and user-facing copy

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ SendMoi currently ships the full core workflow:
 - Use the iOS `UILaunchScreen` asset configuration (`AppIconBackground` + `Splash`) directly at startup, without an extra in-app splash overlay.
 - Use a settings-style form on iPhone and iPad, and a desktop card layout on macOS.
 - Show a branded first-run setup guide with step-by-step onboarding, Gmail connect/switch, and a final “ready” step that can save recipient defaults before entering settings.
+- Keep the onboarding hero demo video fully silent without interrupting background audio from other apps.
 - Let users reopen setup from the app and run a destructive reset flow that disconnects Gmail and clears saved setup preferences.
 
 The app is built entirely with Apple-native frameworks, including `SwiftUI`, `AuthenticationServices`, `Network`, `Security`, and `FoundationModels` when available.

--- a/SendMoi/ContentView.swift
+++ b/SendMoi/ContentView.swift
@@ -2318,7 +2318,7 @@ private final class LoopingVideoPlayerModel: ObservableObject {
             return
         }
 
-        let item = AVPlayerItem(url: url)
+        let item = Self.makeVideoOnlyItem(url: url)
         looper = AVPlayerLooper(player: queuePlayer, templateItem: item)
     }
 
@@ -2328,6 +2328,29 @@ private final class LoopingVideoPlayerModel: ObservableObject {
 
     func pause() {
         player.pause()
+    }
+
+    private static func makeVideoOnlyItem(url: URL) -> AVPlayerItem {
+        let sourceAsset = AVURLAsset(url: url)
+        let composition = AVMutableComposition()
+        guard
+            let sourceVideoTrack = sourceAsset.tracks(withMediaType: .video).first,
+            let videoOnlyCompositionTrack = composition.addMutableTrack(
+                withMediaType: .video,
+                preferredTrackID: kCMPersistentTrackID_Invalid
+            )
+        else {
+            return AVPlayerItem(url: url)
+        }
+
+        do {
+            let timeRange = CMTimeRange(start: .zero, duration: sourceAsset.duration)
+            try videoOnlyCompositionTrack.insertTimeRange(timeRange, of: sourceVideoTrack, at: .zero)
+            videoOnlyCompositionTrack.preferredTransform = sourceVideoTrack.preferredTransform
+            return AVPlayerItem(asset: composition)
+        } catch {
+            return AVPlayerItem(url: url)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- build the onboarding hero loop from a video-only `AVPlayerItem` composition
- preserve looping behavior and video transform while removing audio tracks that can claim focus
- document the behavior in README and HANDOFF

## Validation
- `xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -configuration Debug -destination 'generic/platform=iOS' -derivedDataPath /tmp/sendmoi-dd-FDHqXo build`
- manual scope check: `git diff --name-status origin/main...codex/onboarding-video-no-audio-focus-pr`

Closes #37