### PR TITLE
Fix Switch Account button wrapping in onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,4 +23,4 @@
 - If required details are missing, ask a short follow-up question before creating the issue.
 - If the user provides screenshots/videos, include them in the issue:
   - use existing URLs directly when available
-  - otherwise upload media into the repo (for example under `docs/bugs/...`) and link it in the issue body.
+  - if media is local-only, ask for a shareable URL or confirm the user will attach it manually (do not require committing media into this repo).

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,7 +4,7 @@ Last updated: March 11, 2026
 
 ## Current State
 
-- Repo: `main`
+- Repo: `codex/issue-36-switch-account-wrap` (based on `origin/main`)
 - Latest intended app version: `0.3`
 - Recent shipped commits:
   - `ec40844` `Use Icon Composer .icon file as app icon source, drop legacy PNG appiconset (#33)`
@@ -21,6 +21,8 @@ Last updated: March 11, 2026
 
 ## What Changed Recently
 
+- Onboarding connected-account layout now preserves a one-line `Switch Account` button label by prioritizing button width and allowing the email/details text block to truncate first.
+- `AGENTS.md` issue-media guidance no longer requires uploading screenshots/videos into the repo (for example `docs/bugs/...`); local-only media can be user-attached manually.
 - Share-sheet behavior is now controlled by a global `Auto-send` setting in the main app instead of living inside the compose form.
 - The default recipient is now a separate top-level `Recipient` section instead of being nested inside the collapsed `Account` view.
 - The default recipient field now saves via the keyboard submit action (`Done`) and via an explicit prominent `Save Default Recipient` button that dismisses focus before saving.

--- a/SendMoi/ContentView.swift
+++ b/SendMoi/ContentView.swift
@@ -544,19 +544,27 @@ struct ContentView: View {
                         VStack(alignment: .leading, spacing: 2) {
                             Text(model.session?.emailAddress ?? "Signed in to Gmail")
                                 .font(.body.weight(.medium))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
 
                             Text("You can switch accounts before finishing setup.")
                                 .font(.footnote)
                                 .foregroundStyle(.secondary)
+                                .lineLimit(2)
                         }
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
-                        Spacer(minLength: 0)
-
-                        Button("Switch Account") {
+                        Button {
                             showsOnboardingAccountSheet = true
+                        } label: {
+                            Text("Switch Account")
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.95)
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.regular)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .layoutPriority(2)
                     }
                     .padding(.horizontal, 14)
                     .padding(.vertical, 12)


### PR DESCRIPTION
## Summary
- keep the onboarding `Switch Account` control on a single line by giving the button fixed horizontal size and higher layout priority
- allow connected account text to truncate/compress first to avoid button label wrapping
- update `AGENTS.md` issue-media guidance to stop requiring repo uploads for local-only screenshots/videos
- update `HANDOFF.md` for current branch/focus

## Testing
- `xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`

Fixes #36