### PR TITLE
Improve summary quality and X-share URL/image fallbacks

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -62,7 +62,8 @@ Last updated: March 10, 2026
   - share-extension media is persisted into the shared App Group container and deleted after send / queue deletion
   - the share extension activation rule now accepts image, text, URL, HTML, and property-list payloads
   - X/Twitter share text and Overcast links are normalized more aggressively before sending
-  - shared X/Twitter links now prefer canonical tweet/content URLs, with an X oEmbed fallback for tweet previews when page metadata is weak
+  - shared X/Twitter links now prefer canonical tweet/content URLs, including promotion away from `t.co` short links when the resolved status URL is available, with an X oEmbed fallback when page metadata is weak
+  - when X/Twitter metadata does not provide a preview image, the share extension now attempts a Link Presentation image fallback (including `t.co` and `pic.twitter.com` links) and stores the result in the shared container for inline send
   - low-quality summaries are filtered more aggressively, and summaries are skipped for X/Twitter and Overcast sources
   - the restored `desktopComposeCard` keeps the macOS compose panel buildable again after the helper was accidentally dropped from `ContentView.swift`, while preserving the current share-sheet-only drafting flow
   - iOS startup now relies on `UILaunchScreen` in `Info.plist`; the extra in-app splash overlay was removed so the startup mark matches the launch asset instead of rendering an SF Symbol paper plane
@@ -82,7 +83,7 @@ Last updated: March 10, 2026
    - App Store Connect screenshot previously showed macOS app version `1.0`
 5. Publish stable public URLs for both the privacy policy and terms page on `nieder.me`, then attach those URLs to the Google OAuth consent screen so the blue missing-policy banner disappears.
 6. Share a photo directly from Photos (without a URL) and confirm it can be queued, sent, and removed without leaving orphaned files in the App Group container.
-7. Share an X/Twitter post and an Overcast episode and confirm the title / source URL / summary behavior looks intentional rather than noisy.
+7. Share an X/Twitter post (including `t.co` and `/video/`/`/photo/` variants) and an Overcast episode and confirm title, source URL, summary, and preview image behavior all look intentional rather than noisy.
 8. Run the macOS target and confirm the desktop card layout feels right at common window sizes, especially queue deletion and account disclosure behavior.
 9. Run `./scripts/prepare_release.sh --version <next-version>` before the next archive, then verify App Store Connect accepts the `AppIcon` set for both iOS and macOS and shows the expected branded thumbnail.
 10. Confirm the next Xcode Cloud upload succeeds with build number `3`; the previous failure was `The bundle version must be higher than the previously uploaded version.`

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ For reachable web URLs, SendMoi attempts to enrich the message before sending:
 - Renders the HTML email as a responsive card layout for desktop and mobile clients.
 - Normalizes common shared-post formats, including X/Twitter share text and Overcast titles, before building the email.
 - Promotes real article URLs out of shared social-post text when possible, instead of preserving short links or social wrapper URLs.
+- For X/Twitter shares, canonicalizes `.../video/1` or `.../photo/1` URLs back to the tweet status URL, and promotes `t.co` short links to the resolved status URL when possible so source links stay readable.
 
 If metadata lookup fails, SendMoi falls back to the title, description, image, and URL captured from the shared item.
 
@@ -70,6 +71,7 @@ The `SendMoiShare` extension is included for iPhone, iPad, and macOS share sheet
 - If no default recipient is saved, the share sheet shows a neutral inline helper under `To`, then promotes that guidance into a red validation message only after you tap `Send` without a recipient; on iPhone and iPad it also returns focus to the `To` field so you can fix it immediately.
 - If immediate delivery fails, it writes the message into the shared queue and exits cleanly.
 - If the host app only supplies a URL, the extension can still fetch metadata and allow manual editing before queueing.
+- If URL metadata for an X/Twitter share is missing a preview image, the share extension now tries a Link Presentation image fallback (including `t.co` and `pic.twitter.com` variants) and stores that image in the shared container for inline send.
 - Image-only shares from apps like Photos are stored in the shared App Group container, then cleaned up after send or deletion.
 
 ## Distribution

--- a/SendMoi/Services/GmailDeliveryService.swift
+++ b/SendMoi/Services/GmailDeliveryService.swift
@@ -197,7 +197,7 @@ final class GmailDeliveryService {
             )
         }
 
-        let url = Self.canonicalizedTweetURL(rawURL)
+        let url = await Self.resolvedContentURL(for: rawURL)
         let sanitizedFallbackExcerpt = Self.isMeaninglessTweetExcerpt(fallbackExcerpt, for: url) ? "" : fallbackExcerpt
         guard
               let scheme = url.scheme?.lowercased(),
@@ -225,7 +225,18 @@ final class GmailDeliveryService {
             )
         }
 
-        let resolvedURLString = Self.canonicalizedTweetURLString(metadata.urlString ?? url.absoluteString) ?? (metadata.urlString ?? url.absoluteString)
+        let resolvedURLString = Self.preferredResolvedSourceURLString(
+            metadataURLString: metadata.urlString,
+            requestURLString: url.absoluteString,
+            fetchedTitle: metadata.title,
+            fetchedExcerpt: metadata.excerpt
+        )
+        let derivedSocialTitle = Self.derivedSocialTitle(
+            resolvedURLString: resolvedURLString,
+            metadataURLString: metadata.urlString,
+            fetchedTitle: metadata.title
+        )
+        let socialFallbackTitle = Self.normalizedDisplayText(derivedSocialTitle ?? fallbackTitle)
         let resolvedImageURLStrings = Self.preferredImageURLStrings(
             from: metadata,
             fallbackImageURLStrings: fallbackImageURLStrings,
@@ -247,14 +258,113 @@ final class GmailDeliveryService {
             resolvedExcerpt = metadata.excerpt ?? sanitizedFallbackExcerpt
         }
 
+        let preferredFetchedTitle = metadata.title ?? socialFallbackTitle
+        let resolvedTitle: String
+        if Self.shouldUseSocialFallbackTitle(preferredFetchedTitle, resolvedURLString: resolvedURLString) {
+            resolvedTitle = socialFallbackTitle
+        } else {
+            resolvedTitle = preferredFetchedTitle
+        }
+
         return EmailContent(
-            title: shouldPreferParsedSocialShare ? fallbackTitle : (metadata.title ?? fallbackTitle),
+            title: shouldPreferParsedSocialShare ? socialFallbackTitle : resolvedTitle,
             excerpt: resolvedExcerpt,
             summary: metadata.summary ?? fallbackSummary,
             urlString: resolvedURLString,
             imageURLStrings: resolvedImageURLStrings,
             inlineImages: inlineImages
         )
+    }
+
+    private static func resolvedContentURL(for rawURL: URL) async -> URL {
+        let canonicalRawURL = canonicalizedTweetURL(rawURL)
+        guard let host = canonicalRawURL.host?.lowercased(),
+              host == "t.co" else {
+            return canonicalRawURL
+        }
+
+        var request = URLRequest(url: canonicalRawURL)
+        request.httpMethod = "HEAD"
+        request.timeoutInterval = 4
+        request.setValue("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1", forHTTPHeaderField: "User-Agent")
+
+        do {
+            let (_, response) = try await URLSession.sendMoiMetadata.data(for: request)
+            if let expandedURL = preferredExpandedURL(from: response, fallbackURL: canonicalRawURL) {
+                return canonicalizedTweetURL(expandedURL)
+            }
+        } catch {}
+
+        var fallbackRequest = request
+        fallbackRequest.httpMethod = "GET"
+
+        do {
+            let (_, response) = try await URLSession.sendMoiMetadata.data(for: fallbackRequest)
+            if let expandedURL = preferredExpandedURL(from: response, fallbackURL: canonicalRawURL) {
+                return canonicalizedTweetURL(expandedURL)
+            }
+        } catch {}
+
+        return canonicalRawURL
+    }
+
+    private static func preferredExpandedURL(from response: URLResponse, fallbackURL: URL) -> URL? {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            return nil
+        }
+
+        if let location = httpResponse.value(forHTTPHeaderField: "Location"),
+           let redirectedURL = URL(string: location, relativeTo: fallbackURL)?.absoluteURL {
+            return redirectedURL
+        }
+
+        return httpResponse.url
+    }
+
+    private static func isTweetShortenerHost(_ host: String) -> Bool {
+        let normalized = host.lowercased()
+        return normalized == "t.co" || normalized == "www.t.co"
+    }
+
+    private static func isTweetShortenerURL(_ url: URL) -> Bool {
+        guard let host = url.host else {
+            return false
+        }
+
+        return isTweetShortenerHost(host)
+    }
+
+    private static func preferredResolvedSourceURLString(
+        metadataURLString: String?,
+        requestURLString: String,
+        fetchedTitle: String?,
+        fetchedExcerpt: String?
+    ) -> String {
+        let primary = canonicalizedTweetURLString(metadataURLString ?? requestURLString) ?? (metadataURLString ?? requestURLString)
+        guard let primaryURL = URL(string: primary),
+              isTweetShortenerURL(primaryURL) else {
+            return primary
+        }
+
+        let candidates = [fetchedTitle, fetchedExcerpt]
+        for candidate in candidates {
+            guard let detected = firstDetectedWebURLString(in: candidate) else {
+                continue
+            }
+
+            let canonical = canonicalizedTweetURLString(detected) ?? detected
+            guard
+                  let canonicalURL = URL(string: canonical) else {
+                continue
+            }
+
+            let host = canonicalURL.host?.lowercased() ?? ""
+            if !isTweetShortenerHost(host) {
+                return canonical
+            }
+        }
+
+        return primary
     }
 
     private func fetchArticleMetadata(for url: URL, fallbackTitle: String) async -> FetchedArticleMetadata? {
@@ -272,7 +382,6 @@ final class GmailDeliveryService {
     }
 
     private func fetchAndCacheArticleMetadata(for canonicalURL: URL) async -> CachedArticleMetadata? {
-        let shouldTryXOEmbedFallback = Self.isTweetHost(canonicalURL)
         var request = URLRequest(url: canonicalURL)
         request.httpMethod = "GET"
         request.setValue("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", forHTTPHeaderField: "Accept")
@@ -282,16 +391,17 @@ final class GmailDeliveryService {
 
         do {
             let (data, response) = try await URLSession.sendMoiMetadata.data(for: request)
+            let responseURL = Self.canonicalizedTweetURL((response as? HTTPURLResponse)?.url ?? canonicalURL)
+            let shouldTryXOEmbedFallback = Self.isTweetHost(canonicalURL) || Self.isTweetHost(responseURL)
             guard let httpResponse = response as? HTTPURLResponse,
                   (200..<300).contains(httpResponse.statusCode),
                   let html = decodeHTML(data: data) else {
                 if shouldTryXOEmbedFallback {
-                    return await fetchXOEmbedMetadata(for: canonicalURL)
+                    return await fetchXOEmbedMetadata(for: responseURL)
                 }
                 return nil
             }
 
-            let responseURL = Self.canonicalizedTweetURL(httpResponse.url ?? canonicalURL)
             let metaTags = Self.extractMetaTags(from: html)
             var instagramMetadata = Self.extractInstagramPostMetadata(fromHTML: html, baseURL: responseURL)
             if instagramMetadata == nil,
@@ -340,7 +450,7 @@ final class GmailDeliveryService {
             await Self.previewMetadataCache.store(metadata, for: canonicalURL.absoluteString)
             return metadata
         } catch {
-            if shouldTryXOEmbedFallback {
+            if Self.isTweetHost(canonicalURL) {
                 return await fetchXOEmbedMetadata(for: canonicalURL)
             }
             return nil
@@ -961,6 +1071,10 @@ final class GmailDeliveryService {
            pathComponents[1].lowercased() == "status",
            pathComponents[3].lowercased() == "mediaviewer" {
             normalizedPathComponents = Array(pathComponents.prefix(3))
+        } else if pathComponents.count >= 5,
+                  pathComponents[1].lowercased() == "status",
+                  (pathComponents[3].lowercased() == "video" || pathComponents[3].lowercased() == "photo") {
+            normalizedPathComponents = Array(pathComponents.prefix(3))
         } else if pathComponents.count >= 2,
                   pathComponents.last?.lowercased() == "mediaviewer",
                   let tweetID = components.queryItems?.first(where: { $0.name == "currentTweet" })?.value,
@@ -1291,6 +1405,93 @@ final class GmailDeliveryService {
         }
 
         return excerpt.isEmpty || excerpt == "x" || excerpt == "twitter"
+    }
+
+    private static func derivedSocialTitle(
+        resolvedURLString: String,
+        metadataURLString: String?,
+        fetchedTitle: String?
+    ) -> String? {
+        if let title = SharedPostTextParser.derivedSocialPostShare(
+            from: canonicalizedTweetURLString(resolvedURLString) ?? resolvedURLString
+        )?.title {
+            return title
+        }
+
+        if let metadataURLString,
+           let title = SharedPostTextParser.derivedSocialPostShare(
+               from: canonicalizedTweetURLString(metadataURLString) ?? metadataURLString
+           )?.title {
+            return title
+        }
+
+        if let urlCandidate = firstDetectedWebURLString(in: fetchedTitle),
+           let title = SharedPostTextParser.derivedSocialPostShare(
+               from: canonicalizedTweetURLString(urlCandidate) ?? urlCandidate
+           )?.title {
+            return title
+        }
+
+        return nil
+    }
+
+    private static func firstDetectedWebURLString(in text: String?) -> String? {
+        guard let text = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty,
+              let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            return nil
+        }
+
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        for match in detector.matches(in: text, options: [], range: range) {
+            guard
+                match.resultType == .link,
+                let url = match.url,
+                let scheme = url.scheme?.lowercased(),
+                scheme == "http" || scheme == "https"
+            else {
+                continue
+            }
+
+            return url.absoluteString
+        }
+
+        return nil
+    }
+
+    private static func shouldUseSocialFallbackTitle(_ fetchedTitle: String, resolvedURLString: String) -> Bool {
+        let trimmed = fetchedTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return true
+        }
+
+        let lowered = trimmed.lowercased()
+        if lowered == "x" || lowered == "twitter" || lowered == "x / ?" {
+            return true
+        }
+
+        if let fetchedURL = URL(string: trimmed),
+           isTweetHost(fetchedURL) {
+            return true
+        }
+
+        if lowered.contains("/status/"),
+           lowered.contains("http") {
+            return true
+        }
+
+        if lowered.contains("twitter.com/") || lowered.contains("x.com/") {
+            return true
+        }
+
+        if let host = URL(string: resolvedURLString)?.host?.lowercased() {
+            let condensedHost = host.replacingOccurrences(of: "www.", with: "")
+            if lowered == host || lowered == condensedHost {
+                return true
+            }
+        }
+
+        return false
     }
 
     private static func parseAttributes(from tag: String) -> [String: String] {
@@ -2433,6 +2634,17 @@ final class GmailDeliveryService {
            preservesProviderSourceHosts.contains(responseHost),
            candidateHost != responseHost {
             return responseURL.absoluteString
+        }
+
+        if isTweetShortenerHost(candidateHost) {
+            if let responseHost = normalizedHost(from: responseURL),
+               !isTweetShortenerHost(responseHost) {
+                return responseURL.absoluteString
+            }
+
+            if !isTweetShortenerHost(requestHost) {
+                return requestURL.absoluteString
+            }
         }
 
         return candidateURLString

--- a/SendMoiShare/ShareExtensionModel.swift
+++ b/SendMoiShare/ShareExtensionModel.swift
@@ -1,6 +1,12 @@
 import Foundation
+import LinkPresentation
 import SwiftUI
 import UniformTypeIdentifiers
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 @MainActor
 final class ShareExtensionModel: ObservableObject {
@@ -337,10 +343,20 @@ final class ShareExtensionModel: ObservableObject {
             }
 
             guard let self else { return }
-            let metadata = await self.deliveryService.fetchDraftPreview(
+            var metadata = await self.deliveryService.fetchDraftPreview(
                 urlString: normalizedURLString,
                 fallbackTitle: titleSnapshot
             )
+            if metadata?.imageURLString == nil,
+               Self.shouldAttemptSocialImageFallback(for: normalizedURLString),
+               let fallbackImageURLString = await Self.fetchLinkPreviewImageURLString(for: normalizedURLString) {
+                metadata = DraftPreviewMetadata(
+                    title: metadata?.title,
+                    description: metadata?.description,
+                    summary: metadata?.summary,
+                    imageURLString: fallbackImageURLString
+                )
+            }
 
             await MainActor.run {
                 guard self.urlString.trimmingCharacters(in: .whitespacesAndNewlines) == normalizedURLString else {
@@ -656,6 +672,108 @@ final class ShareExtensionModel: ObservableObject {
         let condensedHost = host.replacingOccurrences(of: "www.", with: "")
         return loweredTitle == host || loweredTitle == condensedHost
     }
+
+    private static func shouldAttemptSocialImageFallback(for urlString: String) -> Bool {
+        guard let host = URL(string: urlString)?.host?.lowercased() else {
+            return false
+        }
+
+        return host == "x.com" ||
+            host == "www.x.com" ||
+            host == "twitter.com" ||
+            host == "www.twitter.com" ||
+            host == "t.co" ||
+            host == "www.t.co" ||
+            host == "pic.twitter.com" ||
+            host == "www.pic.twitter.com"
+    }
+
+    private static func fetchLinkPreviewImageURLString(for urlString: String) async -> String? {
+        guard let url = URL(string: urlString) else {
+            return nil
+        }
+
+        let provider = LPMetadataProvider()
+        provider.timeout = 5
+
+        do {
+            let metadata = try await provider.startFetchingMetadata(for: url)
+            guard let imageProvider = metadata.imageProvider,
+                  let (imageData, fileExtension) = await loadImageData(from: imageProvider),
+                  let fileURL = try? SharedContainer.storeSharedMedia(data: imageData, fileExtension: fileExtension) else {
+                return nil
+            }
+
+            return fileURL.absoluteString
+        } catch {
+            return nil
+        }
+    }
+
+    private static func loadImageData(from provider: NSItemProvider) async -> (Data, String)? {
+        let candidates: [(String, String)] = [
+            (UTType.jpeg.identifier, "jpg"),
+            (UTType.png.identifier, "png"),
+            (UTType.heic.identifier, "heic"),
+            (UTType.gif.identifier, "gif")
+        ]
+
+        for (typeIdentifier, fileExtension) in candidates where provider.hasItemConformingToTypeIdentifier(typeIdentifier) {
+            if let data = await loadDataRepresentation(from: provider, typeIdentifier: typeIdentifier) {
+                return (data, fileExtension)
+            }
+        }
+
+#if canImport(UIKit)
+        if let image = await loadUIImage(from: provider),
+           let data = image.jpegData(compressionQuality: 0.92) {
+            return (data, "jpg")
+        }
+#elseif canImport(AppKit)
+        if let image = await loadNSImage(from: provider),
+           let tiffData = image.tiffRepresentation,
+           let bitmap = NSBitmapImageRep(data: tiffData),
+           let data = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.92]) {
+            return (data, "jpg")
+        }
+#endif
+
+        return nil
+    }
+
+    private static func loadDataRepresentation(from provider: NSItemProvider, typeIdentifier: String) async -> Data? {
+        await withCheckedContinuation { continuation in
+            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, _ in
+                continuation.resume(returning: data)
+            }
+        }
+    }
+
+#if canImport(UIKit)
+    private static func loadUIImage(from provider: NSItemProvider) async -> UIImage? {
+        guard provider.canLoadObject(ofClass: UIImage.self) else {
+            return nil
+        }
+
+        return await withCheckedContinuation { continuation in
+            provider.loadObject(ofClass: UIImage.self) { object, _ in
+                continuation.resume(returning: object as? UIImage)
+            }
+        }
+    }
+#elseif canImport(AppKit)
+    private static func loadNSImage(from provider: NSItemProvider) async -> NSImage? {
+        guard provider.canLoadObject(ofClass: NSImage.self) else {
+            return nil
+        }
+
+        return await withCheckedContinuation { continuation in
+            provider.loadObject(ofClass: NSImage.self) { object, _ in
+                continuation.resume(returning: object as? NSImage)
+            }
+        }
+    }
+#endif
 }
 
 private struct PendingPreviewApplication {


### PR DESCRIPTION
## Summary
- harden summary cleanup to strip generic lead-ins and markdown artifacts, and suppress low-signal structured listing summaries
- canonicalize X/Twitter status media URLs (`/video/*`, `/photo/*`) and prefer resolved status URLs over `t.co` short links for source links
- add X/Twitter LinkPresentation image fallback in the share extension, including `t.co` and `pic.twitter.com` variants

## Verification
- xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -destination 'generic/platform=iOS Simulator' build

## Notes
- leaves local `marketing/app-store-screenshots/*` working-tree edits uncommitted