### PR TITLE
Fix SendMoi bundle identifiers after rename

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,7 +4,7 @@ Last updated: March 10, 2026
 
 ## Current State
 
-- Repo: `codex/issue-36-switch-account-wrap` (based on `origin/main`)
+- Repo: `codex/fix-sendmoi-bundle-identifiers` (based on `origin/main`)
 - Latest intended app version: `0.3`
 - Recent shipped commits:
   - `ec40844` `Use Icon Composer .icon file as app icon source, drop legacy PNG appiconset (#33)`
@@ -15,9 +15,9 @@ Last updated: March 10, 2026
 
 1. `git clone https://github.com/niederme/sendmoi.git`
 2. `cd sendmoi`
-3. `git checkout main`
+3. `git checkout codex/fix-sendmoi-bundle-identifiers`
 4. `git pull --rebase origin main`
-5. Open `SendMoi.xcodeproj` in Xcode and continue from `main`.
+5. Open `SendMoi.xcodeproj` in Xcode and continue from `codex/fix-sendmoi-bundle-identifiers`.
 
 ## What Changed Recently
 
@@ -55,7 +55,7 @@ Last updated: March 10, 2026
 - iOS deployment target is now `18.0` for both `SendMoi` and `SendMoiShare`; Foundation Models summary support remains optional at runtime and falls back on unsupported OS versions.
 - New in the current working tree:
   - repo-wide rename from MailMoi to SendMoi: project, targets, schemes, folders, and user-facing copy
-  - bundle identifiers, App Group ID, and shared container/keychain storage identifiers intentionally remain on the existing MailMoi values for upgrade continuity
+  - bundle identifiers now match the renamed app targets: `com.niederme.SendMoi` and `com.niederme.SendMoi.ShareExtension`; shared App Group and storage identifiers remain on the existing MailMoi values for continuity
   - added a first-pass `TERMS.md` so the Google OAuth consent screen can point at a public Terms of Service URL alongside the existing privacy policy
   - `MARKETING_VERSION` is now `0.3` and `CURRENT_PROJECT_VERSION` is now `6` for both targets, set via `./scripts/prepare_release.sh --version 0.3`
   - the legacy `CFBundleIconFile` override was removed

--- a/README.md
+++ b/README.md
@@ -114,5 +114,5 @@ The repo already includes a configured OAuth client ID in [GoogleOAuthConfig.swi
 
 - Background delivery while the app is fully terminated is not implemented. The queue is durable, but retries resume only after the app launches, becomes active, or the share extension runs again.
 - TestFlight distribution is currently configured for internal testing only.
-- Bundle identifiers intentionally remain `com.niederme.MailMoi` and `com.niederme.MailMoi.ShareExtension` for existing-app continuity.
-- Command-line builds still require valid provisioning for `com.niederme.MailMoi` and `com.niederme.MailMoi.ShareExtension`. In Xcode, automatic signing handles this; with `xcodebuild`, use `-allowProvisioningUpdates`.
+- Bundle identifiers now use `com.niederme.SendMoi` and `com.niederme.SendMoi.ShareExtension`.
+- Command-line builds require valid provisioning for `com.niederme.SendMoi` and `com.niederme.SendMoi.ShareExtension`. In Xcode, automatic signing handles this; with `xcodebuild`, use `-allowProvisioningUpdates`.

--- a/SendMoi.xcodeproj/project.pbxproj
+++ b/SendMoi.xcodeproj/project.pbxproj
@@ -23,8 +23,6 @@
 		A1000001000000000000000E /* SharedSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000010 /* SharedSessionStore.swift */; };
 		A1000001000000000000000F /* GmailDeliveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000011 /* GmailDeliveryService.swift */; };
 		A10000010000000000000010 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000013 /* Assets.xcassets */; };
-		DC6FF07B2F55D5CB00415EAC /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = DC6FF07A2F55D5CB00415EAC /* AppIcon.icon */; };
-		DC6FF07D2F55D5CB00415EAC /* sendmoi-demo-hero.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DC6FF07C2F55D5CB00415EAC /* sendmoi-demo-hero.mp4 */; };
 		B10000010000000000000001 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000004 /* Models.swift */; };
 		B10000010000000000000002 /* QueueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000008 /* QueueStore.swift */; };
 		B10000010000000000000003 /* RecipientStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000009 /* RecipientStore.swift */; };
@@ -37,6 +35,8 @@
 		B1000001000000000000000A /* SharedSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000010 /* SharedSessionStore.swift */; };
 		B1000001000000000000000B /* GmailDeliveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000011 /* GmailDeliveryService.swift */; };
 		B1000001000000000000000C /* SafariPreprocessor.js in Resources */ = {isa = PBXBuildFile; fileRef = B20000010000000000000006 /* SafariPreprocessor.js */; };
+		DC6FF07B2F55D5CB00415EAC /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = DC6FF07A2F55D5CB00415EAC /* AppIcon.icon */; };
+		DC6FF07D2F55D5CB00415EAC /* Resources/sendmoi-demo-hero.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DC6FF07C2F55D5CB00415EAC /* Resources/sendmoi-demo-hero.mp4 */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,8 +91,8 @@
 		B20000010000000000000005 /* SendMoiShare.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SendMoiShare.entitlements; sourceTree = "<group>"; };
 		B20000010000000000000006 /* SafariPreprocessor.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = SafariPreprocessor.js; sourceTree = "<group>"; };
 		B20000010000000000000007 /* SendMoiShare-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "SendMoiShare-macOS.entitlements"; sourceTree = "<group>"; };
-		DC6FF07A2F55D5CB00415EAC /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = "AppIcon.icon"; sourceTree = "<group>"; };
-		DC6FF07C2F55D5CB00415EAC /* sendmoi-demo-hero.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Resources/sendmoi-demo-hero.mp4"; sourceTree = "<group>"; };
+		DC6FF07A2F55D5CB00415EAC /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
+		DC6FF07C2F55D5CB00415EAC /* Resources/sendmoi-demo-hero.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Resources/sendmoi-demo-hero.mp4"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -130,7 +130,7 @@
 				A20000010000000000000012 /* SendMoi-macOS.entitlements */,
 				A20000010000000000000013 /* Assets.xcassets */,
 				DC6FF07A2F55D5CB00415EAC /* AppIcon.icon */,
-				DC6FF07C2F55D5CB00415EAC /* sendmoi-demo-hero.mp4 */,
+				DC6FF07C2F55D5CB00415EAC /* Resources/sendmoi-demo-hero.mp4 */,
 				A20000010000000000000001 /* SendMoiApp.swift */,
 				A20000010000000000000002 /* ContentView.swift */,
 				A20000010000000000000003 /* AppModel.swift */,
@@ -260,7 +260,7 @@
 			files = (
 				A10000010000000000000010 /* Assets.xcassets in Resources */,
 				DC6FF07B2F55D5CB00415EAC /* AppIcon.icon in Resources */,
-				DC6FF07D2F55D5CB00415EAC /* sendmoi-demo-hero.mp4 in Resources */,
+				DC6FF07D2F55D5CB00415EAC /* Resources/sendmoi-demo-hero.mp4 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -439,7 +439,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = com.niederme.MailMoi;
+				PRODUCT_BUNDLE_IDENTIFIER = com.niederme.SendMoi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -468,7 +468,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = com.niederme.MailMoi;
+				PRODUCT_BUNDLE_IDENTIFIER = com.niederme.SendMoi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -497,7 +497,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = com.niederme.MailMoi.ShareExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.niederme.SendMoi.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -527,7 +527,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 0.3;
-				PRODUCT_BUNDLE_IDENTIFIER = com.niederme.MailMoi.ShareExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.niederme.SendMoi.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";


### PR DESCRIPTION
## Summary
- update `SendMoi` and `SendMoiShare` target bundle identifiers from legacy `MailMoi` IDs to `SendMoi` IDs
- align `README.md` known-limitations/provisioning notes with the new bundle IDs
- update `HANDOFF.md` branch context and recent-change note for this config update

## Validation
- `plutil -lint SendMoi.xcodeproj/project.pbxproj`

Closes #41
