### PR TITLE
Make Offline Queue collapsible with prominent retry CTA

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,7 +4,7 @@ Last updated: March 10, 2026
 
 ## Current State
 
-- Repo: `codex/fix-sendmoi-bundle-identifiers` (based on `origin/main`)
+- Repo: `codex/offline-queue-collapsible-cta` (based on `origin/main`)
 - Latest intended app version: `0.3`
 - Recent shipped commits:
   - `ec40844` `Use Icon Composer .icon file as app icon source, drop legacy PNG appiconset (#33)`
@@ -15,12 +15,13 @@ Last updated: March 10, 2026
 
 1. `git clone https://github.com/niederme/sendmoi.git`
 2. `cd sendmoi`
-3. `git checkout codex/fix-sendmoi-bundle-identifiers`
+3. `git checkout codex/offline-queue-collapsible-cta`
 4. `git pull --rebase origin main`
-5. Open `SendMoi.xcodeproj` in Xcode and continue from `codex/fix-sendmoi-bundle-identifiers`.
+5. Open `SendMoi.xcodeproj` in Xcode and continue from `codex/offline-queue-collapsible-cta`.
 
 ## What Changed Recently
 
+- Opened issue `#43` (`Make Offline Queue collapsible with prominent retry CTA`) and updated iPhone/iPad settings so `Offline Queue` now uses a collapsible disclosure row with summary text plus a full-width prominent `Send Queued Now` action when expanded.
 - Onboarding connected-account layout now preserves a one-line `Switch Account` button label by prioritizing button width and allowing the email/details text block to truncate first.
 - `AGENTS.md` issue-media guidance no longer requires uploading screenshots/videos into the repo (for example `docs/bugs/...`); local-only media can be user-attached manually.
 - Share-sheet behavior is now controlled by a global `Auto-send` setting in the main app instead of living inside the compose form.
@@ -95,6 +96,7 @@ Last updated: March 10, 2026
 14. Share a concise profile/homepage URL that includes a newsletter mention in body copy and confirm SendMoi still generates a short summary when the page has meaningful text.
 15. Confirm App Store Connect processing reports iOS compatibility as `iOS 18.0 or later` after uploading the next archive.
 16. Share a Zillow or Ticketmaster listing URL and confirm SendMoi omits low-quality structured summaries instead of sending scraped listing blobs, markdown artifacts, or generic "Here is a summary..." prefixes.
+17. On iPhone and iPad, verify the `Offline Queue` section now starts collapsed when the queue is empty, auto-expands when queued items exist, and still allows manual retry + deletion from the expanded state.
 
 ## Local Setup
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ SendMoi currently ships the full core workflow:
 - Let the share sheet either send immediately or stay open with a pre-filled draft, based on the global `Auto-send` setting in the app.
 - Use the iOS `UILaunchScreen` asset configuration (`AppIconBackground` + `Splash`) directly at startup, without an extra in-app splash overlay.
 - Use a settings-style form on iPhone and iPad, and a desktop card layout on macOS.
+- Show the iPhone/iPad `Offline Queue` section as a collapsible row with queue-state summary text and a prominent `Send Queued Now` action in the expanded content.
 - Show a branded first-run setup guide with step-by-step onboarding, Gmail connect/switch, and a final “ready” step that can save recipient defaults before entering settings.
 - Keep the onboarding hero demo video fully silent without interrupting background audio from other apps.
 - Let users reopen setup from the app and run a destructive reset flow that disconnects Gmail and clears saved setup preferences.

--- a/SendMoi/AppModel.swift
+++ b/SendMoi/AppModel.swift
@@ -11,6 +11,7 @@ final class AppModel: ObservableObject {
     @Published var isBusy = false
     @Published var isOnline = false
     @Published var isAccountSectionExpanded = true
+    @Published var isQueueSectionExpanded = false
     @Published var shouldShowOnboarding = false
 
     private let client = GmailAPIClient()
@@ -179,8 +180,18 @@ final class AppModel: ObservableObject {
     }
 
     private func reloadQueueFromDisk() {
+        let previousCount = queuedEmails.count
+
         do {
             queuedEmails = try QueueStore.load()
+            let hasQueuedEmails = !queuedEmails.isEmpty
+            let hadQueuedEmails = previousCount > 0
+
+            if hasQueuedEmails && !hadQueuedEmails {
+                isQueueSectionExpanded = true
+            } else if !hasQueuedEmails {
+                isQueueSectionExpanded = false
+            }
         } catch {
             statusMessage = "Could not load the offline queue: \(error.localizedDescription)"
         }

--- a/SendMoi/ContentView.swift
+++ b/SendMoi/ContentView.swift
@@ -1207,6 +1207,28 @@ struct ContentView: View {
         model.isOnline ? "Network looks available. The app retries automatically." : "Offline or unreachable. Items remain queued."
     }
 
+    private var queueSummaryTitle: String {
+        let count = model.queuedEmails.count
+
+        if count == 0 {
+            return "No pending emails"
+        }
+
+        return "\(count) pending email\(count == 1 ? "" : "s")"
+    }
+
+    private var queueSummaryDetail: String {
+        if model.isBusy && !model.queuedEmails.isEmpty {
+            return "Retry in progress"
+        }
+
+        if model.queuedEmails.isEmpty {
+            return "Queue is clear"
+        }
+
+        return "Tap to review and send now"
+    }
+
     private func saveDefaultRecipient() {
         focusedField = nil
         model.setDefaultRecipient(model.defaultRecipient)
@@ -1225,36 +1247,50 @@ struct ContentView: View {
 
     private var queueSection: some View {
         Section {
-            if model.queuedEmails.isEmpty {
-                Text("No pending emails.")
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(model.queuedEmails) { item in
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(item.title)
-                            .font(.headline)
-                        Text("To: \(item.toEmail)")
-                            .font(.subheadline)
-                        Text(item.urlString)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                        if let lastError = item.lastError {
-                            Text(lastError)
+            DisclosureGroup(isExpanded: $model.isQueueSectionExpanded) {
+                if model.queuedEmails.isEmpty {
+                    Text("No pending emails.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(model.queuedEmails) { item in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(item.title)
+                                .font(.headline)
+                            Text("To: \(item.toEmail)")
+                                .font(.subheadline)
+                            Text(item.urlString)
                                 .font(.footnote)
-                                .foregroundStyle(.orange)
+                                .foregroundStyle(.secondary)
+                            if let lastError = item.lastError {
+                                Text(lastError)
+                                    .font(.footnote)
+                                    .foregroundStyle(.orange)
+                            }
                         }
+                        .padding(.vertical, 4)
                     }
-                    .padding(.vertical, 4)
+                    .onDelete(perform: model.deleteQueuedEmails)
                 }
-                .onDelete(perform: model.deleteQueuedEmails)
-            }
-
-            Button("Send Queued Now") {
-                Task {
-                    await model.retryNow()
+                Button {
+                    Task {
+                        await model.retryNow()
+                    }
+                } label: {
+                    Text("Send Queued Now")
+                        .frame(maxWidth: .infinity)
                 }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(model.isBusy || model.queuedEmails.isEmpty)
+            } label: {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(queueSummaryTitle)
+                    Text(queueSummaryDetail)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 2)
             }
-            .disabled(model.isBusy || model.queuedEmails.isEmpty)
         } header: {
             Text("Offline Queue")
         } footer: {


### PR DESCRIPTION
Closes #43\n\n## Summary\n- make iPhone/iPad Offline Queue section a DisclosureGroup with queue summary text\n- keep queue rows + delete behavior inside the expanded content\n- style `Send Queued Now` as a full-width prominent CTA\n- auto-expand queue section when items appear and collapse when queue becomes empty\n- update README + HANDOFF\n\n## Verification\n- xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -sdk iphonesimulator -configuration Debug CODE_SIGNING_ALLOWED=NO build