### PR TITLE
Document streamlined feature-to-PR workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,18 +18,19 @@
 - Commit at sensible, verifiable milestones without waiting for approval.
 - Multiple commits per branch are fine; keep them scoped and readable.
 - Do not include unrelated working tree changes in commits unless explicitly requested.
-- Before every commit, review `README.md` and `HANDOFF.md`.
-- Update `README.md` whenever setup steps, commands, behavior, or other user-facing documentation changed.
-- Update `HANDOFF.md` whenever the working branch, current focus, recent changes, open items, or resume steps changed.
-- Do not finalize a commit until `README.md` and `HANDOFF.md` are updated or explicitly confirmed to still be accurate.
+- Update docs during development when the commit changes setup steps, commands, behavior, or active-branch context.
+- Prefer milestone-sized doc updates during implementation to reduce conflict churn.
 
 ### 3) When Asked To Open A PR
 - Confirm the issue number to link in the PR. If missing, ask before creating the PR.
 - Complete relevant tests/checks.
+- Run a full docs reconciliation pass before opening the PR:
+  - review `README.md` and `HANDOFF.md` end-to-end
+  - update both files to match the final branch state, or explicitly confirm they are still accurate
 - Sync branch right before PR creation:
   - `git fetch origin`
   - `git rebase origin/main` (or merge `origin/main` when rebase is not appropriate)
-- Resolve conflicts, rerun checks, then push:
+- Resolve conflicts, rerun checks, and re-verify `README.md` / `HANDOFF.md`, then push:
   - normal push: `git push -u origin codex/<short-slug>`
   - after rebase: `git push --force-with-lease`
 - Open PR against `main` and link the issue in the PR body using `Closes #<issue-number>`.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -21,6 +21,7 @@ Last updated: March 10, 2026
 
 ## What Changed Recently
 
+- `AGENTS.md` now uses a faster documentation cadence: keep doc updates lightweight during implementation, then require one full `README.md` + `HANDOFF.md` reconciliation pass right before opening a PR (plus recheck after rebase/conflict resolution).
 - `AGENTS.md` now removes separate `Commit Workflow` / `Git Workflow` sections and folds those rules directly into the single `Delivery Lifecycle Workflow` (start, implement/commit, PR, post-merge) so there is one canonical process.
 - `AGENTS.md` now clarifies that `Commit Workflow` and `Git Workflow` are guardrails that are explicitly incorporated into the end-to-end `Delivery Lifecycle Workflow` steps, so there is one canonical process instead of parallel checklists.
 - `AGENTS.md` now includes an explicit end-to-end delivery lifecycle: start from issue + fresh `codex/*` branch off updated `main`, rebase/merge from `origin/main` before opening PR, require PR issue linkage (`Closes #...`), and run post-merge cleanup (`main` sync, branch deletion, optional worktree prune).


### PR DESCRIPTION
## Summary
- consolidate process docs into a single Delivery Lifecycle Workflow
- fold prior commit/git rules into lifecycle steps (start, implement/commit, PR, post-merge)
- switch to PR-gated documentation reconciliation for speed: lightweight doc updates during implementation, full README/HANDOFF pass before PR
- keep GitHub issue media guidance explicit (use URL or manual attachment)

## Testing
- docs-only change
- no code/test execution required