### PR TITLE
Handle stale Gmail send scopes with reconnect flow

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,10 +1,10 @@
 # SendMoi Handoff
 
-Last updated: March 10, 2026
+Last updated: March 27, 2026
 
 ## Current State
 
-- Repo: `codex/guard-remote-branch-delete` (based on `origin/main`)
+- Repo: `codex/reconnect-gmail-scope` (based on `origin/main`)
 - Latest intended app version: `0.3`
 - Recent shipped commits:
   - `ec40844` `Use Icon Composer .icon file as app icon source, drop legacy PNG appiconset (#33)`
@@ -22,6 +22,7 @@ Last updated: March 10, 2026
 ## What Changed Recently
 
 - `AGENTS.md` post-merge cleanup now marks remote branch deletion as conditional (`git push origin --delete codex/<short-slug> (if remote branch exists)`) to avoid noisy errors when GitHub already removed the branch.
+- Gmail queue recovery now detects the Gmail API `insufficient authentication scopes` failure, keeps the item in the offline queue, and surfaces explicit `Reconnect Gmail` actions in both the queue and account UI so users can repair stale/under-scoped sessions without guessing.
 - `AGENTS.md` now uses a faster documentation cadence: keep doc updates lightweight during implementation, then require one full `README.md` + `HANDOFF.md` reconciliation pass right before opening a PR (plus recheck after rebase/conflict resolution).
 - `AGENTS.md` now removes separate `Commit Workflow` / `Git Workflow` sections and folds those rules directly into the single `Delivery Lifecycle Workflow` (start, implement/commit, PR, post-merge) so there is one canonical process.
 - `AGENTS.md` now clarifies that `Commit Workflow` and `Git Workflow` are guardrails that are explicitly incorporated into the end-to-end `Delivery Lifecycle Workflow` steps, so there is one canonical process instead of parallel checklists.
@@ -104,6 +105,7 @@ Last updated: March 10, 2026
 15. Confirm App Store Connect processing reports iOS compatibility as `iOS 18.0 or later` after uploading the next archive.
 16. Share a Zillow or Ticketmaster listing URL and confirm SendMoi omits low-quality structured summaries instead of sending scraped listing blobs, markdown artifacts, or generic "Here is a summary..." prefixes.
 17. On iPhone and iPad, verify the `Offline Queue` section now starts collapsed when the queue is empty, auto-expands when queued items exist, and still allows manual retry + deletion from the expanded state.
+18. Reproduce a stale or under-scoped Gmail session, confirm queued sends show `Reconnect Gmail`, complete reauth, and verify the queued items then send successfully.
 
 ## Local Setup
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ SendMoi currently ships the full core workflow:
 - Handle links, pasted post text, and image-only shares as first-class queueable items.
 - Queue every outbound email locally before network delivery.
 - Retry queued emails when the app launches, becomes active, or connectivity returns.
+- Detect missing Gmail send permission on queued delivery failures and prompt the user to reconnect Gmail before retrying.
 - Share queue state, saved recipients, and session data through the App Group `group.com.niederme.mailmoi`.
 - Let the share sheet either send immediately or stay open with a pre-filled draft, based on the global `Auto-send` setting in the app.
 - Use the iOS `UILaunchScreen` asset configuration (`AppIconBackground` + `Splash`) directly at startup, without an extra in-app splash overlay.

--- a/SendMoi/AppModel.swift
+++ b/SendMoi/AppModel.swift
@@ -12,6 +12,7 @@ final class AppModel: ObservableObject {
     @Published var isOnline = false
     @Published var isAccountSectionExpanded = true
     @Published var isQueueSectionExpanded = false
+    @Published var requiresGmailReconnect = false
     @Published var shouldShowOnboarding = false
 
     private let client = GmailAPIClient()
@@ -54,22 +55,25 @@ final class AppModel: ObservableObject {
     func signIn() async -> Bool {
         guard !isBusy else { return false }
         isBusy = true
+        var didSignIn = false
 
         do {
             let signedInSession = try await client.signIn()
             session = signedInSession
             try KeychainStore.save(session: signedInSession)
             try SharedSessionStore.save(signedInSession)
+            requiresGmailReconnect = false
             statusMessage = "Signed in as \(signedInSession.emailAddress ?? "your Gmail account")."
             isAccountSectionExpanded = false
             reloadQueueFromDisk()
+            didSignIn = true
         } catch {
             statusMessage = "Sign in failed: \(error.localizedDescription)"
         }
 
         isBusy = false
 
-        if session != nil {
+        if didSignIn {
             await processQueue()
             return true
         }
@@ -83,6 +87,7 @@ final class AppModel: ObservableObject {
             try KeychainStore.clearSession()
             SharedSessionStore.clear()
             session = nil
+            requiresGmailReconnect = false
             isAccountSectionExpanded = true
             statusMessage = "Signed out. Queued items stay on disk until you send them."
         } catch {
@@ -118,13 +123,28 @@ final class AppModel: ObservableObject {
                     RecipientStore.record(next.toEmail)
                     statusMessage = "Sent \"\(next.title)\" to \(next.toEmail)."
                 } catch {
-                    markFailure(for: next.id, message: error.localizedDescription)
-                    statusMessage = "Queued item kept for retry: \(error.localizedDescription)"
+                    if let gmailError = error as? GmailAPIError, gmailError.requiresReconnect {
+                        requiresGmailReconnect = true
+                        isAccountSectionExpanded = true
+                        isQueueSectionExpanded = true
+                        markFailure(for: next.id, message: gmailError.localizedDescription)
+                        statusMessage = "Reconnect Gmail to grant send permission. Queued items will send after you reconnect."
+                    } else {
+                        markFailure(for: next.id, message: error.localizedDescription)
+                        statusMessage = "Queued item kept for retry: \(error.localizedDescription)"
+                    }
                     break
                 }
             }
         } catch {
-            statusMessage = "Queue processing paused: \(error.localizedDescription)"
+            if let gmailError = error as? GmailAPIError, gmailError.requiresReconnect {
+                requiresGmailReconnect = true
+                isAccountSectionExpanded = true
+                isQueueSectionExpanded = true
+                statusMessage = "Reconnect Gmail to grant send permission. Queued items will send after you reconnect."
+            } else {
+                statusMessage = "Queue processing paused: \(error.localizedDescription)"
+            }
         }
     }
 
@@ -192,6 +212,8 @@ final class AppModel: ObservableObject {
             } else if !hasQueuedEmails {
                 isQueueSectionExpanded = false
             }
+
+            updateReconnectRequirement()
         } catch {
             statusMessage = "Could not load the offline queue: \(error.localizedDescription)"
         }
@@ -211,13 +233,25 @@ final class AppModel: ObservableObject {
             removeManagedMedia(for: item)
         }
         queuedEmails.removeAll { ids.contains($0.id) }
+        updateReconnectRequirement()
         persistQueue()
     }
 
     private func markFailure(for id: UUID, message: String) {
         if let index = queuedEmails.firstIndex(where: { $0.id == id }) {
             queuedEmails[index].lastError = message
+            updateReconnectRequirement()
             persistQueue()
+        }
+    }
+
+    private func updateReconnectRequirement() {
+        requiresGmailReconnect = queuedEmails.contains { item in
+            guard let lastError = item.lastError else {
+                return false
+            }
+
+            return GmailAPIError.indicatesInsufficientAuthenticationScopes(lastError)
         }
     }
 

--- a/SendMoi/ContentView.swift
+++ b/SendMoi/ContentView.swift
@@ -1112,6 +1112,20 @@ struct ContentView: View {
             DisclosureGroup(isExpanded: $model.isAccountSectionExpanded) {
                 if let session = model.session {
                     LabeledContent("From", value: session.emailAddress ?? "Authenticated via Gmail")
+
+                    if model.requiresGmailReconnect {
+                        Text("The saved Gmail session is missing send permission.")
+                            .font(.footnote)
+                            .foregroundStyle(.orange)
+
+                        Button("Reconnect Gmail") {
+                            Task {
+                                await model.signIn()
+                            }
+                        }
+                        .disabled(model.isBusy || !GoogleOAuthConfig.isConfigured)
+                    }
+
                     Button("Sign Out") {
                         model.signOut()
                     }
@@ -1208,6 +1222,10 @@ struct ContentView: View {
     }
 
     private var accountSectionFooterText: String {
+        if model.requiresGmailReconnect {
+            return "Reconnect Gmail to restore send permission for queued items."
+        }
+
         if usesDesktopLayout {
         return "Manage Gmail sign-in for the desktop app."
         } else {
@@ -1216,6 +1234,10 @@ struct ContentView: View {
     }
 
     private var queueFooterText: String {
+        if model.requiresGmailReconnect {
+            return "Reconnect Gmail to restore send permission, then retry the queue."
+        }
+
         model.isOnline ? "Network looks available. The app retries automatically." : "Offline or unreachable. Items remain queued."
     }
 
@@ -1236,6 +1258,10 @@ struct ContentView: View {
 
         if model.queuedEmails.isEmpty {
             return "Queue is clear"
+        }
+
+        if model.requiresGmailReconnect {
+            return "Reconnect Gmail to resume sending"
         }
 
         return "Tap to review and send now"
@@ -1283,6 +1309,21 @@ struct ContentView: View {
                     }
                     .onDelete(perform: model.deleteQueuedEmails)
                 }
+
+                if model.requiresGmailReconnect {
+                    Button {
+                        Task {
+                            await model.signIn()
+                        }
+                    } label: {
+                        Text("Reconnect Gmail")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .disabled(model.isBusy || !GoogleOAuthConfig.isConfigured)
+                }
+
                 Button {
                     Task {
                         await model.retryNow()
@@ -1293,7 +1334,7 @@ struct ContentView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
-                .disabled(model.isBusy || model.queuedEmails.isEmpty)
+                .disabled(model.isBusy || model.queuedEmails.isEmpty || model.requiresGmailReconnect)
             } label: {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(queueSummaryTitle)
@@ -1807,6 +1848,24 @@ extension ContentView {
                 if let session = model.session {
                     desktopReadout(label: "Signed in as", value: session.emailAddress ?? "Authenticated via Gmail")
 
+                    if model.requiresGmailReconnect {
+                        Text("The saved Gmail session is missing send permission.")
+                            .font(.footnote)
+                            .foregroundStyle(.orange)
+
+                        HStack {
+                            Button("Reconnect Gmail") {
+                                Task {
+                                    await model.signIn()
+                                }
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .disabled(model.isBusy || !GoogleOAuthConfig.isConfigured)
+
+                            Spacer()
+                        }
+                    }
+
                     HStack {
                         Button("Sign Out", role: .destructive) {
                             model.signOut()
@@ -2015,7 +2074,25 @@ extension ContentView {
                             await model.retryNow()
                         }
                     }
-                    .disabled(model.isBusy || model.queuedEmails.isEmpty)
+                    .disabled(model.isBusy || model.queuedEmails.isEmpty || model.requiresGmailReconnect)
+                }
+
+                if model.requiresGmailReconnect {
+                    HStack {
+                        Text("Reconnect Gmail, then retry the queue.")
+                            .font(.footnote)
+                            .foregroundStyle(.orange)
+
+                        Spacer()
+
+                        Button("Reconnect Gmail") {
+                            Task {
+                                await model.signIn()
+                            }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(model.isBusy || !GoogleOAuthConfig.isConfigured)
+                    }
                 }
             }
         }

--- a/SendMoi/Services/GmailAPIClient.swift
+++ b/SendMoi/Services/GmailAPIClient.swift
@@ -142,10 +142,7 @@ final class GmailAPIClient {
             }
 
             guard (200..<300).contains(httpResponse.statusCode) else {
-                if let message = Self.extractErrorMessage(from: data) {
-                    throw GmailAPIError.api(message)
-                }
-                throw GmailAPIError.api("Google API returned status \(httpResponse.statusCode).")
+                throw Self.apiError(from: data, statusCode: httpResponse.statusCode)
             }
 
             return data
@@ -175,6 +172,18 @@ final class GmailAPIClient {
         }
 
         return nil
+    }
+
+    private static func apiError(from data: Data, statusCode: Int) -> GmailAPIError {
+        if let message = extractErrorMessage(from: data) {
+            if GmailAPIError.indicatesInsufficientAuthenticationScopes(message) {
+                return .insufficientAuthenticationScopes
+            }
+
+            return .api(message)
+        }
+
+        return .api("Google API returned status \(statusCode).")
     }
 
     private static func authorizationError(from queryItems: [URLQueryItem]) -> GmailAPIError? {

--- a/SendMoi/Services/GmailShared.swift
+++ b/SendMoi/Services/GmailShared.swift
@@ -7,6 +7,7 @@ enum GmailAPIError: LocalizedError {
     case invalidRedirect
     case invalidState
     case signInCanceled
+    case insufficientAuthenticationScopes
     case authorizationFailed(String)
     case rateLimitExceeded(String)
     case transport(Error)
@@ -26,6 +27,8 @@ enum GmailAPIError: LocalizedError {
             return "The OAuth redirect did not match the original sign-in request."
         case .signInCanceled:
             return "Google sign-in was canceled."
+        case .insufficientAuthenticationScopes:
+            return "Reconnect Gmail to grant send permission."
         case .authorizationFailed(let message):
             return message
         case .rateLimitExceeded(let message):
@@ -35,6 +38,22 @@ enum GmailAPIError: LocalizedError {
         case .api(let message):
             return message
         }
+    }
+
+    var requiresReconnect: Bool {
+        switch self {
+        case .insufficientAuthenticationScopes:
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func indicatesInsufficientAuthenticationScopes(_ message: String) -> Bool {
+        let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return normalized.localizedCaseInsensitiveContains("insufficient authentication scopes")
+            || normalized.localizedCaseInsensitiveContains("grant send permission")
     }
 }
 


### PR DESCRIPTION
## Summary
- detect Gmail send failures caused by insufficient authentication scopes as a first-class reconnect condition
- keep affected items in the offline queue and surface explicit Reconnect Gmail actions in the queue and account UI
- document the new reconnect-recovery behavior in README.md and HANDOFF.md

## Testing
- `git diff --check`
- full Xcode build not run in this environment