### PR TITLE
Redesign Mac UI as single-column settings window

### DIFF
--- a/SendMoi/Mac/MacControlCenterView.swift
+++ b/SendMoi/Mac/MacControlCenterView.swift
@@ -12,26 +12,22 @@ struct MacControlCenterView: View {
 
             Divider()
 
-            contentSplit
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    if !model.queuedEmails.isEmpty || model.requiresGmailReconnect {
+                        MacQueuePane()
+                    }
+
+                    MacSetupSidebar(
+                        openSetupGuide: openSetupGuide,
+                        showResetConfirmation: showResetConfirmation
+                    )
+                }
+                .padding(20)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.primary.opacity(0.02))
-    }
-
-    private var contentSplit: some View {
-        HStack(spacing: 0) {
-            MacQueuePane()
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-
-            Divider()
-
-            MacSetupSidebar(
-                openSetupGuide: openSetupGuide,
-                showResetConfirmation: showResetConfirmation
-            )
-            .frame(width: 340)
-            .frame(maxHeight: .infinity, alignment: .topLeading)
-        }
     }
 }
 
@@ -50,12 +46,29 @@ private struct MacControlCenterView_Previews: PreviewProvider {
                     defaultRecipient: "ideas@sendmoi.app",
                     shareSheetAutoSendEnabled: true,
                     session: SendMoiPreviewFixtures.connectedSession,
+                    statusMessage: "SendMoi retries automatically when the network and Gmail session are healthy.",
+                    isOnline: true
+                )
+            )
+            .frame(width: 640, height: 700)
+            .previewDisplayName("With Queue")
+
+            MacControlCenterView(
+                openSetupGuide: {},
+                showResetConfirmation: {}
+            )
+            .environmentObject(
+                SendMoiPreviewFixtures.appModel(
+                    queuedEmails: [],
+                    defaultRecipient: "ideas@sendmoi.app",
+                    shareSheetAutoSendEnabled: true,
+                    session: SendMoiPreviewFixtures.connectedSession,
                     statusMessage: "Signed in as founder@sendmoi.app.",
                     isOnline: true
                 )
             )
-            .frame(width: 1120, height: 720)
-            .previewDisplayName("Healthy Queue")
+            .frame(width: 640, height: 560)
+            .previewDisplayName("Settings Only")
 
             MacControlCenterView(
                 openSetupGuide: {},
@@ -72,7 +85,7 @@ private struct MacControlCenterView_Previews: PreviewProvider {
                     requiresGmailReconnect: true
                 )
             )
-            .frame(width: 1120, height: 720)
+            .frame(width: 640, height: 700)
             .previewDisplayName("Reconnect Required")
         }
     }

--- a/SendMoi/Mac/MacQueuePane.swift
+++ b/SendMoi/Mac/MacQueuePane.swift
@@ -4,34 +4,26 @@ struct MacQueuePane: View {
     @EnvironmentObject private var model: AppModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            header
+        MacSidebarCard(
+            title: "Queue",
+            subtitle: cardSubtitle
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                actionButtons
 
-            Divider()
-
-            if model.queuedEmails.isEmpty {
-                emptyState
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 14) {
-                        ForEach(displayedQueue) { item in
-                            MacQueueRow(
-                                item: item,
-                                isRetryCandidate: item.id == retryCandidateID,
-                                retryDisabled: model.isBusy || model.requiresGmailReconnect,
-                                onRetry: retryQueue,
-                                onDelete: {
-                                    model.deleteQueuedEmail(id: item.id)
-                                }
-                            )
+                ForEach(displayedQueue) { item in
+                    MacQueueRow(
+                        item: item,
+                        isRetryCandidate: item.id == retryCandidateID,
+                        retryDisabled: model.isBusy || model.requiresGmailReconnect,
+                        onRetry: retryQueue,
+                        onDelete: {
+                            model.deleteQueuedEmail(id: item.id)
                         }
-                    }
-                    .padding(20)
+                    )
                 }
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     private var displayedQueue: [QueuedEmail] {
@@ -42,116 +34,38 @@ struct MacQueuePane: View {
         model.queuedEmails.last?.id
     }
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top, spacing: 16) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Queue")
-                        .font(.system(size: 28, weight: .semibold))
-
-                    Text(queueSummary)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 12)
-
-                HStack(spacing: 10) {
-                    if model.requiresGmailReconnect {
-                        Button("Reconnect Gmail") {
-                            Task {
-                                await model.signIn()
-                            }
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .disabled(model.isBusy || !GoogleOAuthConfig.isConfigured)
-                    }
-
-                    if model.requiresGmailReconnect {
-                        Button("Retry All") {
-                            retryQueue()
-                        }
-                        .buttonStyle(.bordered)
-                        .disabled(true)
-                    } else {
-                        Button("Retry All") {
-                            retryQueue()
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .disabled(model.isBusy || model.queuedEmails.isEmpty)
-                    }
-                }
-            }
-
-            Text(model.statusMessage)
-                .font(.footnote)
-                .foregroundStyle(model.requiresGmailReconnect ? .orange : .secondary)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(Color.primary.opacity(0.04))
-                )
-        }
-        .padding(20)
-    }
-
-    private var emptyState: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Image(systemName: "tray")
-                .font(.system(size: 28, weight: .semibold))
-                .foregroundStyle(.secondary)
-
-            Text("Queue is clear")
-                .font(.title3.weight(.semibold))
-
-            Text(queueSummary)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            HStack(spacing: 10) {
-                if model.requiresGmailReconnect {
-                    Button("Reconnect Gmail") {
-                        Task {
-                            await model.signIn()
-                        }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(model.isBusy || !GoogleOAuthConfig.isConfigured)
-                }
-
-                Button("Retry All") {
-                    retryQueue()
-                }
-                .buttonStyle(.bordered)
-                .disabled(model.isBusy || model.queuedEmails.isEmpty || model.requiresGmailReconnect)
-            }
-        }
-        .padding(28)
-        .frame(maxWidth: 480, alignment: .leading)
-    }
-
-    private var queueSummary: String {
+    private var cardSubtitle: String {
         if model.requiresGmailReconnect {
             return "Reconnect Gmail to restore send permission, then retry the queue."
         }
-
-        if model.queuedEmails.isEmpty {
-            return model.isOnline
-                ? "Nothing is waiting right now. Shared items that cannot send immediately will appear here."
-                : "Nothing is waiting right now. If the network drops, shared items will queue here until SendMoi can retry."
-        }
-
         return model.isOnline
             ? "SendMoi retries automatically when the network and Gmail session are healthy."
             : "Items stay here until the app can reach the network again."
     }
 
-    private func retryQueue() {
-        Task {
-            await model.retryNow()
+    @ViewBuilder
+    private var actionButtons: some View {
+        HStack(spacing: 10) {
+            if model.requiresGmailReconnect {
+                Button("Reconnect Gmail") {
+                    Task { await model.signIn() }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(model.isBusy || !GoogleOAuthConfig.isConfigured)
+            }
+
+            if !model.queuedEmails.isEmpty {
+                Button("Retry All") {
+                    retryQueue()
+                }
+                .buttonStyle(model.requiresGmailReconnect ? .bordered : .borderedProminent)
+                .disabled(model.isBusy || model.requiresGmailReconnect)
+            }
         }
+    }
+
+    private func retryQueue() {
+        Task { await model.retryNow() }
     }
 }
 
@@ -228,10 +142,7 @@ private struct MacQueueRow: View {
     }
 
     private var sourceLabel: String? {
-        guard !item.urlString.isEmpty else {
-            return nil
-        }
-
+        guard !item.urlString.isEmpty else { return nil }
         return URL(string: item.urlString)?.host ?? item.urlString
     }
 }
@@ -252,22 +163,25 @@ private struct MacQueuePane_Previews: PreviewProvider {
                         isOnline: true
                     )
                 )
-                .frame(width: 760, height: 520)
+                .frame(width: 620, height: 400)
+                .padding(20)
                 .previewDisplayName("Queued Items")
 
             MacQueuePane()
                 .environmentObject(
                     SendMoiPreviewFixtures.appModel(
-                        queuedEmails: [],
+                        queuedEmails: SendMoiPreviewFixtures.reconnectQueue,
                         defaultRecipient: "ideas@sendmoi.app",
-                        shareSheetAutoSendEnabled: true,
+                        shareSheetAutoSendEnabled: false,
                         session: SendMoiPreviewFixtures.connectedSession,
-                        statusMessage: "Nothing is waiting right now.",
-                        isOnline: true
+                        statusMessage: "Reconnect Gmail to restore send permission.",
+                        isOnline: false,
+                        requiresGmailReconnect: true
                     )
                 )
-                .frame(width: 760, height: 520)
-                .previewDisplayName("Empty Queue")
+                .frame(width: 620, height: 400)
+                .padding(20)
+                .previewDisplayName("Reconnect Required")
         }
     }
 }

--- a/SendMoi/Mac/MacSetupSidebar.swift
+++ b/SendMoi/Mac/MacSetupSidebar.swift
@@ -7,18 +7,13 @@ struct MacSetupSidebar: View {
     let showResetConfirmation: () -> Void
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                gmailCard
-                recipientCard
-                shareBehaviorCard
-                setupCard
-            }
-            .padding(16)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
+        VStack(alignment: .leading, spacing: 16) {
+            gmailCard
+            recipientCard
+            shareBehaviorCard
+            setupCard
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .background(.regularMaterial)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 
     private var gmailCard: some View {
@@ -38,7 +33,7 @@ struct MacSetupSidebar: View {
                         Text(model.session?.emailAddress ?? "No Gmail account connected")
                             .font(.headline)
 
-                        Text(model.session == nil ? "SendMoi needs Gmail to send queued items." : "Signed in to Gmail")
+                        Text(model.session == nil ? "SendMoi needs Gmail to send queued items." : "Ready for queued delivery on this Mac.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     }
@@ -46,15 +41,10 @@ struct MacSetupSidebar: View {
                     Spacer(minLength: 0)
                 }
 
-                if let session = model.session {
-                    LabeledContent("Signed in as", value: session.emailAddress ?? "Authenticated via Gmail")
-                        .font(.footnote)
-
+                if model.session != nil {
                     if model.requiresGmailReconnect {
                         Button("Reconnect Gmail") {
-                            Task {
-                                await model.signIn()
-                            }
+                            Task { await model.signIn() }
                         }
                         .buttonStyle(.borderedProminent)
                         .disabled(model.isBusy || !GoogleOAuthConfig.isConfigured)
@@ -67,9 +57,7 @@ struct MacSetupSidebar: View {
                     .disabled(model.isBusy)
                 } else {
                     Button("Sign In With Google") {
-                        Task {
-                            await model.signIn()
-                        }
+                        Task { await model.signIn() }
                     }
                     .buttonStyle(.borderedProminent)
                     .disabled(model.isBusy || !GoogleOAuthConfig.isConfigured)
@@ -97,7 +85,7 @@ struct MacSetupSidebar: View {
                 Button("Save Default Recipient") {
                     saveDefaultRecipient()
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.bordered)
                 .disabled(model.isBusy)
             }
         }
@@ -131,10 +119,6 @@ struct MacSetupSidebar: View {
             subtitle: "Reopen the guide or reset SendMoi to first launch."
         ) {
             VStack(alignment: .leading, spacing: 12) {
-                Text(model.statusMessage)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-
                 Button("Open Setup Guide") {
                     openSetupGuide()
                 }
@@ -155,7 +139,7 @@ struct MacSetupSidebar: View {
     }
 }
 
-private struct MacSidebarCard<Content: View>: View {
+struct MacSidebarCard<Content: View>: View {
     let title: String
     let subtitle: String
     @ViewBuilder let content: Content
@@ -205,7 +189,8 @@ private struct MacSetupSidebar_Previews: PreviewProvider {
                     isOnline: true
                 )
             )
-            .frame(width: 340, height: 560)
+            .frame(width: 620, height: 560)
+            .padding(20)
             .previewDisplayName("Connected Setup")
 
             MacSetupSidebar(
@@ -221,7 +206,8 @@ private struct MacSetupSidebar_Previews: PreviewProvider {
                     isOnline: false
                 )
             )
-            .frame(width: 340, height: 560)
+            .frame(width: 620, height: 560)
+            .padding(20)
             .previewDisplayName("Needs Setup")
         }
     }

--- a/SendMoi/Mac/MacStatusHeader.swift
+++ b/SendMoi/Mac/MacStatusHeader.swift
@@ -4,76 +4,32 @@ struct MacStatusHeader: View {
     @EnvironmentObject private var model: AppModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .center, spacing: 12) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("SendMoi")
-                        .font(.title3.weight(.semibold))
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("SendMoi")
+                    .font(.title3.weight(.semibold))
 
-                    Text("Control Center")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 16)
-
-                ViewThatFits(in: .horizontal) {
-                    HStack(spacing: 10) {
-                        statusPill(
-                            title: "Account",
-                            value: accountStatus,
-                            systemImage: model.session == nil ? "person.crop.circle.badge.xmark" : "person.crop.circle.badge.checkmark"
-                        )
-
-                        statusPill(
-                            title: "Network",
-                            value: model.isOnline ? "Online" : "Offline",
-                            systemImage: model.isOnline ? "wifi" : "wifi.slash",
-                            tint: model.isOnline ? .green : .orange
-                        )
-
-                        statusPill(
-                            title: "Queue",
-                            value: "\(model.queuedEmails.count) queued",
-                            systemImage: "tray.full"
-                        )
-                    }
-
-                    VStack(alignment: .trailing, spacing: 8) {
-                        statusPill(
-                            title: "Account",
-                            value: accountStatus,
-                            systemImage: model.session == nil ? "person.crop.circle.badge.xmark" : "person.crop.circle.badge.checkmark"
-                        )
-
-                        HStack(spacing: 8) {
-                            statusPill(
-                                title: "Network",
-                                value: model.isOnline ? "Online" : "Offline",
-                                systemImage: model.isOnline ? "wifi" : "wifi.slash",
-                                tint: model.isOnline ? .green : .orange
-                            )
-
-                            statusPill(
-                                title: "Queue",
-                                value: "\(model.queuedEmails.count) queued",
-                                systemImage: "tray.full"
-                            )
-                        }
-                    }
-                }
+                Text("Settings")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
-            HStack(spacing: 8) {
-                if model.requiresGmailReconnect {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.orange)
+            Spacer(minLength: 16)
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 10) {
+                    accountPill
+                    networkPill
+                    queuePill
                 }
 
-                Text(model.statusMessage)
-                    .font(.footnote)
-                    .foregroundStyle(model.requiresGmailReconnect ? .orange : .secondary)
-                    .lineLimit(2)
+                VStack(alignment: .trailing, spacing: 8) {
+                    accountPill
+                    HStack(spacing: 8) {
+                        networkPill
+                        queuePill
+                    }
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -81,8 +37,33 @@ struct MacStatusHeader: View {
         .background(.thinMaterial)
     }
 
-    private var accountStatus: String {
-        model.session?.emailAddress ?? "Not Connected"
+    private var accountPill: some View {
+        statusPill(
+            title: "Account",
+            value: model.session?.emailAddress ?? "Not Connected",
+            systemImage: model.session == nil ? "person.crop.circle.badge.xmark" : "person.crop.circle.badge.checkmark",
+            tint: model.session == nil ? .orange : .accentColor
+        )
+    }
+
+    private var networkPill: some View {
+        statusPill(
+            title: "Network",
+            value: model.isOnline ? "Online" : "Offline",
+            systemImage: model.isOnline ? "wifi" : "wifi.slash",
+            tint: model.isOnline ? .green : .orange
+        )
+    }
+
+    private var queuePill: some View {
+        let count = model.queuedEmails.count
+        let hasIssue = model.requiresGmailReconnect || count > 0
+        return statusPill(
+            title: "Queue",
+            value: count == 0 ? "Clear" : "\(count) waiting",
+            systemImage: count == 0 ? "tray" : "tray.full",
+            tint: hasIssue ? .orange : .secondary
+        )
     }
 
     private func statusPill(

--- a/SendMoi/SendMoiApp.swift
+++ b/SendMoi/SendMoiApp.swift
@@ -14,7 +14,7 @@ struct SendMoiApp: App {
                 }
         }
         #if os(macOS)
-        .defaultSize(width: 1040, height: 920)
+        .defaultSize(width: 640, height: 560)
         .windowResizability(.contentMinSize)
         .restorationBehavior(.disabled)
         #endif


### PR DESCRIPTION
## Summary

- Replaces the split-pane "control center" layout with a single scrollable settings view — settings cards full-width, no persistent queue pane
- Queue section only renders when `queuedEmails` is non-empty or Gmail reconnect is required; disappears on the happy path
- Removes all redundant status message text rows and the duplicate `LabeledContent("Signed in as")` label from the Gmail card
- Demotes "Save Default Recipient" from `.borderedProminent` to `.bordered` — it's a one-time setup action, not the primary CTA
- Promotes `MacSidebarCard` from `private` to `internal` so `MacQueuePane` can use it as a card
- Status pills in header updated: Queue pill shows "Clear" / "N waiting" with orange tint on issue, Account pill gets orange tint when disconnected
- Narrows default window from 1040×920 → 640×560 to fit the single-column layout
- Renames subtitle from "Control Center" → "Settings" to match the actual job

## Test plan

- [ ] Build and run on macOS — verify settings cards appear full-width
- [ ] Verify queue section is hidden when queue is empty
- [ ] Share a URL, let it queue offline — confirm Queue card appears at top
- [ ] Reconnect-required state: confirm Queue card appears with Reconnect Gmail button
- [ ] Confirm no duplicate email address visible anywhere in the window
- [ ] Resize window — confirm pills wrap via `ViewThatFits` at narrow widths
- [ ] Check all previews render correctly in Xcode

🤖 Generated with [Claude Code](https://claude.com/claude-code)