### PR TITLE
Fix AI Summary: hide when empty on Mac, use TextField on iOS

### DIFF
--- a/SendMoiShare/ShareView.swift
+++ b/SendMoiShare/ShareView.swift
@@ -360,7 +360,7 @@ struct ShareView: View {
     }
 
     private var previewMetadataSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 6) {
             Text("AI Summary")
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -369,10 +369,10 @@ struct ShareView: View {
                 if model.isRefreshingPreview && model.summary.isEmpty {
                     ProgressView()
                         .controlSize(.small)
-                        .padding(.top, 8)
+                        .padding(.top, 4)
                 } else {
-                    TextEditor(text: $model.summary)
-                        .frame(minHeight: 56)
+                    TextField("", text: $model.summary, axis: .vertical)
+                        .textInputAutocapitalization(.sentences)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -457,11 +457,7 @@ struct ShareView: View {
     }
 
     private var shouldShowSummarySection: Bool {
-        #if os(macOS)
-        return true
-        #else
         model.isRefreshingPreview || !model.summary.isEmpty
-        #endif
     }
 
     private func titleInputField(lineLimit: Int, placeholder: String = "Title") -> some View {


### PR DESCRIPTION
## Summary

- **Mac**: Removed the `#if os(macOS) return true` override in `shouldShowSummarySection` — both platforms now use the same logic (show only when loading or non-empty), preventing the section from appearing as duplicate content alongside the description
- **iOS**: Replaced `TextEditor` with `TextField("", text: $model.summary, axis: .vertical)` to eliminate internal scrollbars and font size inconsistencies, matching the Mac implementation

## Test plan

- [ ] Share a URL on Mac — confirm AI Summary section is hidden when summary is empty, visible when populated
- [ ] Share a URL on iOS — confirm AI Summary field has no internal scrollbars and matches the font size of other fields
- [ ] Confirm AI Summary still editable on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)