### PR TITLE
Lighten SendMoi light-mode background gradient

### DIFF
--- a/docs/accessibility/index.html
+++ b/docs/accessibility/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#ebe9e3" />
+    <meta name="theme-color" content="#f4f1ed" />
     <title>SendMoi Accessibility Statement</title>
     <meta name="description" content="Accessibility Statement for SendMoi by John Niedermeyer." />
     <link rel="canonical" href="https://send.moi/accessibility/" />
@@ -58,10 +58,10 @@
         --violet: #9810fa;
         --pink: #9810fa;
         --page-background:
-          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.9), transparent 24%),
-          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.72), transparent 18%),
-          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.56), transparent 16%),
-          linear-gradient(180deg, #f0eee9 0%, #ebe9e3 42%, #e8e6df 100%);
+          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.95), transparent 24%),
+          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.82), transparent 18%),
+          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.66), transparent 16%),
+          linear-gradient(180deg, #faf8f5 0%, #f4f1ed 42%, #efebe6 100%);
         --shadow-lg: 0 24px 72px rgba(34, 39, 63, 0.14);
         --shadow-md: 0 16px 40px rgba(34, 39, 63, 0.1);
         --theme-toggle-bg: rgba(255, 255, 255, 0.62);
@@ -93,10 +93,10 @@
         --card: rgba(255, 255, 255, 0.84);
         --card-solid: rgba(255, 255, 255, 0.64);
         --page-background:
-          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.9), transparent 24%),
-          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.72), transparent 18%),
-          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.56), transparent 16%),
-          linear-gradient(180deg, #f0eee9 0%, #ebe9e3 42%, #e8e6df 100%);
+          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.95), transparent 24%),
+          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.82), transparent 18%),
+          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.66), transparent 16%),
+          linear-gradient(180deg, #faf8f5 0%, #f4f1ed 42%, #efebe6 100%);
         --shadow-lg: 0 24px 72px rgba(34, 39, 63, 0.14);
         --shadow-md: 0 16px 40px rgba(34, 39, 63, 0.1);
         --theme-toggle-bg: rgba(255, 255, 255, 0.62);

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#ebe9e3" />
+    <meta name="theme-color" content="#f4f1ed" />
     <title>SendMoi | Your inbox, in two taps</title>
     <meta
       name="description"
@@ -77,7 +77,7 @@
       }
 
       :root {
-        --bg: #ebe9e3;
+        --bg: #f4f1ed;
         --ink: #090909;
         --muted: #5d606a;
         --line: rgba(12, 14, 22, 0.1);
@@ -87,14 +87,14 @@
         --blue: #2b7fff;
         --violet: #9810fa;
         --page-background:
-          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.9), transparent 24%),
-          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.72), transparent 18%),
-          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.56), transparent 16%),
-          linear-gradient(180deg, #f0eee9 0%, #ebe9e3 42%, #e8e6df 100%);
+          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.95), transparent 24%),
+          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.82), transparent 18%),
+          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.66), transparent 16%),
+          linear-gradient(180deg, #faf8f5 0%, #f4f1ed 42%, #efebe6 100%);
         --video-background:
-          radial-gradient(circle at 30% 28%, rgba(43, 127, 255, 0.1), transparent 18%),
-          radial-gradient(circle at 68% 58%, rgba(152, 16, 250, 0.1), transparent 20%),
-          linear-gradient(135deg, rgba(255, 255, 255, 0.74), rgba(255, 255, 255, 0.54));
+          radial-gradient(circle at 30% 28%, rgba(43, 127, 255, 0.08), transparent 18%),
+          radial-gradient(circle at 68% 58%, rgba(152, 16, 250, 0.08), transparent 20%),
+          linear-gradient(135deg, rgba(255, 255, 255, 0.84), rgba(255, 255, 255, 0.66));
         --shadow-lg: 0 24px 72px rgba(34, 39, 63, 0.14);
         --shadow-md: 0 16px 40px rgba(34, 39, 63, 0.1);
         --theme-toggle-bg: rgba(255, 255, 255, 0.62);
@@ -124,7 +124,7 @@
       }
 
       html[data-theme="light"] {
-        --bg: #ebe9e3;
+        --bg: #f4f1ed;
         --ink: #090909;
         --muted: #5d606a;
         --line: rgba(12, 14, 22, 0.1);
@@ -132,14 +132,14 @@
         --card: rgba(255, 255, 255, 0.84);
         --card-solid: rgba(255, 255, 255, 0.64);
         --page-background:
-          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.9), transparent 24%),
-          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.72), transparent 18%),
-          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.56), transparent 16%),
-          linear-gradient(180deg, #f0eee9 0%, #ebe9e3 42%, #e8e6df 100%);
+          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.95), transparent 24%),
+          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.82), transparent 18%),
+          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.66), transparent 16%),
+          linear-gradient(180deg, #faf8f5 0%, #f4f1ed 42%, #efebe6 100%);
         --video-background:
-          radial-gradient(circle at 30% 28%, rgba(43, 127, 255, 0.1), transparent 18%),
-          radial-gradient(circle at 68% 58%, rgba(152, 16, 250, 0.1), transparent 20%),
-          linear-gradient(135deg, rgba(255, 255, 255, 0.74), rgba(255, 255, 255, 0.54));
+          radial-gradient(circle at 30% 28%, rgba(43, 127, 255, 0.08), transparent 18%),
+          radial-gradient(circle at 68% 58%, rgba(152, 16, 250, 0.08), transparent 20%),
+          linear-gradient(135deg, rgba(255, 255, 255, 0.84), rgba(255, 255, 255, 0.66));
         --shadow-lg: 0 24px 72px rgba(34, 39, 63, 0.14);
         --shadow-md: 0 16px 40px rgba(34, 39, 63, 0.1);
         --theme-toggle-bg: rgba(255, 255, 255, 0.62);

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#ebe9e3" />
+    <meta name="theme-color" content="#f4f1ed" />
     <title>SendMoi Privacy Policy</title>
     <meta name="description" content="Privacy Policy for SendMoi by John Niedermeyer." />
     <link rel="canonical" href="https://send.moi/privacy/" />
@@ -58,10 +58,10 @@
         --violet: #9810fa;
         --pink: #9810fa;
         --page-background:
-          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.9), transparent 24%),
-          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.72), transparent 18%),
-          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.56), transparent 16%),
-          linear-gradient(180deg, #f0eee9 0%, #ebe9e3 42%, #e8e6df 100%);
+          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.95), transparent 24%),
+          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.82), transparent 18%),
+          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.66), transparent 16%),
+          linear-gradient(180deg, #faf8f5 0%, #f4f1ed 42%, #efebe6 100%);
         --shadow-lg: 0 24px 72px rgba(34, 39, 63, 0.14);
         --shadow-md: 0 16px 40px rgba(34, 39, 63, 0.1);
         --theme-toggle-bg: rgba(255, 255, 255, 0.62);
@@ -93,10 +93,10 @@
         --card: rgba(255, 255, 255, 0.84);
         --card-solid: rgba(255, 255, 255, 0.64);
         --page-background:
-          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.9), transparent 24%),
-          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.72), transparent 18%),
-          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.56), transparent 16%),
-          linear-gradient(180deg, #f0eee9 0%, #ebe9e3 42%, #e8e6df 100%);
+          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.95), transparent 24%),
+          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.82), transparent 18%),
+          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.66), transparent 16%),
+          linear-gradient(180deg, #faf8f5 0%, #f4f1ed 42%, #efebe6 100%);
         --shadow-lg: 0 24px 72px rgba(34, 39, 63, 0.14);
         --shadow-md: 0 16px 40px rgba(34, 39, 63, 0.1);
         --theme-toggle-bg: rgba(255, 255, 255, 0.62);

--- a/docs/terms/index.html
+++ b/docs/terms/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#ebe9e3" />
+    <meta name="theme-color" content="#f4f1ed" />
     <title>SendMoi Terms of Service</title>
     <meta name="description" content="Terms of Service for SendMoi by John Niedermeyer." />
     <link rel="canonical" href="https://send.moi/terms/" />
@@ -58,10 +58,10 @@
         --violet: #9810fa;
         --pink: #9810fa;
         --page-background:
-          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.9), transparent 24%),
-          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.72), transparent 18%),
-          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.56), transparent 16%),
-          linear-gradient(180deg, #f0eee9 0%, #ebe9e3 42%, #e8e6df 100%);
+          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.95), transparent 24%),
+          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.82), transparent 18%),
+          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.66), transparent 16%),
+          linear-gradient(180deg, #faf8f5 0%, #f4f1ed 42%, #efebe6 100%);
         --shadow-lg: 0 24px 72px rgba(34, 39, 63, 0.14);
         --shadow-md: 0 16px 40px rgba(34, 39, 63, 0.1);
         --theme-toggle-bg: rgba(255, 255, 255, 0.62);
@@ -93,10 +93,10 @@
         --card: rgba(255, 255, 255, 0.84);
         --card-solid: rgba(255, 255, 255, 0.64);
         --page-background:
-          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.9), transparent 24%),
-          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.72), transparent 18%),
-          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.56), transparent 16%),
-          linear-gradient(180deg, #f0eee9 0%, #ebe9e3 42%, #e8e6df 100%);
+          radial-gradient(circle at 16% 14%, rgba(255, 255, 255, 0.95), transparent 24%),
+          radial-gradient(circle at 38% 18%, rgba(255, 255, 255, 0.82), transparent 18%),
+          radial-gradient(circle at 62% 24%, rgba(255, 255, 255, 0.66), transparent 16%),
+          linear-gradient(180deg, #faf8f5 0%, #f4f1ed 42%, #efebe6 100%);
         --shadow-lg: 0 24px 72px rgba(34, 39, 63, 0.14);
         --shadow-md: 0 16px 40px rgba(34, 39, 63, 0.1);
         --theme-toggle-bg: rgba(255, 255, 255, 0.62);


### PR DESCRIPTION
## Summary
- lighten the light-mode gray background wash across the SendMoi site
- brighten the homepage hero/video wash without changing dark mode
- keep the existing layout and content intact while making the light theme feel airier

## Verification
- ran `make dev-live`
- reviewed the updated light-mode look locally in the live-reload preview

## Notes
- this PR intentionally does not link an issue