### PR TITLE
Fix iOS share extension not replacing truncated tweet excerpts

### DIFF
--- a/SendMoiShare/ShareExtensionModel.swift
+++ b/SendMoiShare/ShareExtensionModel.swift
@@ -580,7 +580,7 @@ final class ShareExtensionModel: ObservableObject {
             title = previewTitle
         }
 
-        if application.excerptSnapshot.isEmpty,
+        if (application.excerptSnapshot.isEmpty || Self.looksTruncatedSocialExcerpt(application.excerptSnapshot)),
            let previewDescription = application.metadata?.description,
            !previewDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             excerpt = previewDescription
@@ -619,7 +619,7 @@ final class ShareExtensionModel: ObservableObject {
             updatedDraft.title = previewTitle
         }
 
-        if pendingPreviewApplication.excerptSnapshot.isEmpty,
+        if (pendingPreviewApplication.excerptSnapshot.isEmpty || Self.looksTruncatedSocialExcerpt(pendingPreviewApplication.excerptSnapshot)),
            let previewDescription = pendingPreviewApplication.metadata?.description,
            !previewDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             updatedDraft.excerpt = previewDescription


### PR DESCRIPTION
## Problem

When sharing a tweet from iOS, the description field sometimes shows truncated text ending in `...` (e.g. "Most of..."). This happens because:

1. `SafariPreprocessor.js` first tries to extract the tweet text from the live DOM via `[data-testid="tweetText"]`
2. When that fails (e.g. the tweet hasn't fully rendered at share time), it falls back to the `og:description` meta tag — which X.com intentionally truncates
3. The share extension then fetches the full tweet text via oEmbed during `schedulePreviewRefresh`
4. **But** `applyPreviewApplication` and `draftApplyingPendingPreview` both only applied the preview description when `excerptSnapshot.isEmpty` — so the truncated excerpt from the share sheet was never replaced

## Fix

In both `applyPreviewApplication` and `draftApplyingPendingPreview`, changed the condition to also allow the oEmbed result to replace the excerpt when the existing one looks truncated (contains `...` or `…`), using the existing `looksTruncatedSocialExcerpt` helper:

```swift
// Before
if application.excerptSnapshot.isEmpty,

// After
if (application.excerptSnapshot.isEmpty || Self.looksTruncatedSocialExcerpt(application.excerptSnapshot)),
```

## Test plan

- [ ] Share a long tweet from Safari on iOS — description should show the full text after the preview loads
- [ ] Share a short tweet (no truncation) — description should be unaffected
- [ ] Share a non-tweet URL — excerpt behaviour should be unaffected
- [ ] Tap Send immediately (before preview loads) — the queued item should still get the full excerpt applied via `draftApplyingPendingPreview`