### PR TITLE
Fix build error: add looksTruncatedSocialExcerpt to ShareExtensionModel

### DIFF
--- a/SendMoiShare/ShareExtensionModel.swift
+++ b/SendMoiShare/ShareExtensionModel.swift
@@ -1795,6 +1795,12 @@ private enum SharedItemExtractor {
 }
 
 private extension ShareExtensionModel {
+    static func looksTruncatedSocialExcerpt(_ excerpt: String) -> Bool {
+        let trimmed = excerpt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return trimmed.contains("...") || trimmed.contains("…")
+    }
+
     var allImageURLStrings: [String] {
         ([previewImageURLString].compactMap { $0 } + additionalImageURLStrings)
             .reduce(into: [String]()) { result, next in

--- a/SendMoiShare/ShareExtensionModel.swift
+++ b/SendMoiShare/ShareExtensionModel.swift
@@ -580,7 +580,7 @@ final class ShareExtensionModel: ObservableObject {
             title = previewTitle
         }
 
-        if application.excerptSnapshot.isEmpty,
+        if (application.excerptSnapshot.isEmpty || Self.looksTruncatedSocialExcerpt(application.excerptSnapshot)),
            let previewDescription = application.metadata?.description,
            !previewDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             excerpt = previewDescription
@@ -619,7 +619,7 @@ final class ShareExtensionModel: ObservableObject {
             updatedDraft.title = previewTitle
         }
 
-        if pendingPreviewApplication.excerptSnapshot.isEmpty,
+        if (pendingPreviewApplication.excerptSnapshot.isEmpty || Self.looksTruncatedSocialExcerpt(pendingPreviewApplication.excerptSnapshot)),
            let previewDescription = pendingPreviewApplication.metadata?.description,
            !previewDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             updatedDraft.excerpt = previewDescription


### PR DESCRIPTION
Fixes the build error introduced in #62.

`looksTruncatedSocialExcerpt` is `private static` on `SharedItemExtractor`, a separate type in the same file. Calling it as `Self.looksTruncatedSocialExcerpt` from `ShareExtensionModel` methods didn't compile.

Fix: add a matching `static func looksTruncatedSocialExcerpt` to the `private extension ShareExtensionModel`, making it accessible to the main class body per Swift's access control rules (private members are visible across a type and all its extensions in the same file).