### PR TITLE
fix: use single app icon for favicon

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,9 +10,8 @@
       content="Found something cool? SendMoi sends links to Gmail as rich email cards in two taps, so you can close the tab and find it later."
     />
     <link rel="canonical" href="https://send.moi/" />
-    <link rel="icon" type="image/png" href="./assets/images/sendmoi/app-icon-light.png?v=7f526f9eb2a3" />
-    <link rel="icon" type="image/png" href="./assets/images/sendmoi/app-icon-dark.png?v=6bf5d7f5c81c" media="(prefers-color-scheme: dark)" />
-    <link rel="apple-touch-icon" href="./assets/images/sendmoi/app-icon-light.png?v=7f526f9eb2a3" />
+    <link rel="icon" type="image/png" href="./assets/images/sendmoi/app-icon.png" />
+    <link rel="apple-touch-icon" href="./assets/images/sendmoi/app-icon.png" />
 
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />


### PR DESCRIPTION
Swaps the light/dark favicon variants for a single `app-icon.png`. The dark variant (black background) rendered as an unrecognizable blue blob at tab favicon size.