### PR TITLE
Remove coming-soon decoration from Mac badge to fix alignment

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1780,10 +1780,6 @@
                 />
               </a>
               <div class="store-actions--coming-soon">
-                <span class="coming-soon-mark" aria-hidden="true">
-                  <img class="coming-soon-circle" src="./assets/images/sendmoi/coming-soon-circle.svg" alt="" loading="lazy" decoding="async" />
-                  <img class="coming-soon-text" src="./assets/images/sendmoi/coming-soon-text.svg" alt="" loading="lazy" decoding="async" />
-                </span>
                 <a class="store-badge-link" href="#" aria-label="Download SendMoi on the Mac App Store (coming soon)" aria-disabled="true" tabindex="-1">
                   <img
                     class="store-badge store-badge--dark"
@@ -1926,10 +1922,6 @@
             />
           </a>
           <div class="store-actions--coming-soon">
-            <span class="coming-soon-mark" aria-hidden="true">
-              <img class="coming-soon-circle" src="./assets/images/sendmoi/coming-soon-circle.svg" alt="" loading="lazy" decoding="async" />
-              <img class="coming-soon-text" src="./assets/images/sendmoi/coming-soon-text.svg" alt="" loading="lazy" decoding="async" />
-            </span>
             <a class="store-badge-link" href="#" aria-label="Download SendMoi on the Mac App Store (coming soon)" aria-disabled="true" tabindex="-1">
               <img
                 class="store-badge store-badge--dark"


### PR DESCRIPTION
Removes the `coming-soon-mark` span (circle + handwritten text SVGs) from the Mac App Store badge in both the hero and download strip. The Mac badge remains greyed-out and disabled via the `store-actions--coming-soon` class styling. The decoration can be revisited when the Mac app ships.

https://claude.ai/code/session_01LegofwnvVPeeRw5b61dcEf