### PR TITLE
Restore coming-soon decoration on Mac badge

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1780,6 +1780,10 @@
                 />
               </a>
               <div class="store-actions--coming-soon">
+                <span class="coming-soon-mark" aria-hidden="true">
+                  <img class="coming-soon-circle" src="./assets/images/sendmoi/coming-soon-circle.svg" alt="" loading="lazy" decoding="async" />
+                  <img class="coming-soon-text" src="./assets/images/sendmoi/coming-soon-text.svg" alt="" loading="lazy" decoding="async" />
+                </span>
                 <a class="store-badge-link" href="#" aria-label="Download SendMoi on the Mac App Store (coming soon)" aria-disabled="true" tabindex="-1">
                   <img
                     class="store-badge store-badge--dark"
@@ -1922,6 +1926,10 @@
             />
           </a>
           <div class="store-actions--coming-soon">
+            <span class="coming-soon-mark" aria-hidden="true">
+              <img class="coming-soon-circle" src="./assets/images/sendmoi/coming-soon-circle.svg" alt="" loading="lazy" decoding="async" />
+              <img class="coming-soon-text" src="./assets/images/sendmoi/coming-soon-text.svg" alt="" loading="lazy" decoding="async" />
+            </span>
             <a class="store-badge-link" href="#" aria-label="Download SendMoi on the Mac App Store (coming soon)" aria-disabled="true" tabindex="-1">
               <img
                 class="store-badge store-badge--dark"


### PR DESCRIPTION
Brings back the `coming-soon-mark` (circle + handwritten text SVGs) on the Mac App Store badge in both the hero and download strip. The `display:flex` fix on the wrapper means these absolutely-positioned decorations no longer interfere with button alignment.

https://claude.ai/code/session_01LegofwnvVPeeRw5b61dcEf