### PR TITLE
Fix coming-soon decoration color (stop filter cascade)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1164,7 +1164,6 @@
         pointer-events: none;
         cursor: not-allowed;
         opacity: 0.62;
-        filter: grayscale(0.32) saturate(0.48) brightness(1.02) contrast(0.86) !important;
       }
 
       .store-badge-link--coming-soon::before {
@@ -1190,13 +1189,12 @@
 
       .store-badge-link--coming-soon .store-badge {
         opacity: 0.78;
-        filter: saturate(0.74) contrast(0.88) brightness(1.02) !important;
+        filter: grayscale(0.32) saturate(0.48) brightness(1.02) contrast(0.86) !important;
       }
 
       .store-badge-link--coming-soon:hover,
       .store-badge-link--coming-soon:focus-visible {
         transform: none;
-        filter: grayscale(0.32) saturate(0.48) brightness(1.02) contrast(0.86) !important;
       }
 
       .store-badge-link {


### PR DESCRIPTION
The grayscale/saturate filter on `.store-badge-link--coming-soon` was cascading to its children, including the handwritten circle/text decoration, making it appear gray.

Fix: move the desaturation filter from the parent `<a>` to `.store-badge-link--coming-soon .store-badge` so it only affects the Mac badge images. The parent retains `opacity: 0.62` which dims the decoration slightly while preserving its colors.