### PR TITLE
Add GoodLinks saving support

### DIFF
--- a/SendMoi.xcodeproj/project.pbxproj
+++ b/SendMoi.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		A10000010000000000000014 /* MacStatusHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000017 /* MacStatusHeader.swift */; };
 		A10000010000000000000015 /* AnalyticsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000018 /* AnalyticsClient.swift */; };
 		A10000010000000000000016 /* Analytics.plist in Resources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000019 /* Analytics.plist */; };
+		A10000010000000000000017 /* GoodLinksService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000001000000000000001A /* GoodLinksService.swift */; };
+		A10000010000000000000018 /* GoodLinksSyncStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000001000000000000001B /* GoodLinksSyncStore.swift */; };
 		B10000010000000000000001 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000004 /* Models.swift */; };
 		B10000010000000000000002 /* QueueStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000008 /* QueueStore.swift */; };
 		B10000010000000000000003 /* RecipientStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000009 /* RecipientStore.swift */; };
@@ -43,6 +45,8 @@
 		B1000001000000000000000C /* SafariPreprocessor.js in Resources */ = {isa = PBXBuildFile; fileRef = B20000010000000000000006 /* SafariPreprocessor.js */; };
 		B1000001000000000000000D /* AnalyticsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000018 /* AnalyticsClient.swift */; };
 		B1000001000000000000000E /* Analytics.plist in Resources */ = {isa = PBXBuildFile; fileRef = A20000010000000000000019 /* Analytics.plist */; };
+		B1000001000000000000000F /* GoodLinksService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000001000000000000001A /* GoodLinksService.swift */; };
+		B10000010000000000000010 /* GoodLinksSyncStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000001000000000000001B /* GoodLinksSyncStore.swift */; };
 		DC6FF07B2F55D5CB00415EAC /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = DC6FF07A2F55D5CB00415EAC /* AppIcon.icon */; };
 		DC6FF07D2F55D5CB00415EAC /* Resources/sendmoi-demo-hero.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = DC6FF07C2F55D5CB00415EAC /* Resources/sendmoi-demo-hero.mp4 */; };
 /* End PBXBuildFile section */
@@ -98,6 +102,8 @@
 		A20000010000000000000017 /* MacStatusHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacStatusHeader.swift; sourceTree = "<group>"; };
 		A20000010000000000000018 /* AnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClient.swift; sourceTree = "<group>"; };
 		A20000010000000000000019 /* Analytics.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Analytics.plist; sourceTree = "<group>"; };
+		A2000001000000000000001A /* GoodLinksService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoodLinksService.swift; sourceTree = "<group>"; };
+		A2000001000000000000001B /* GoodLinksSyncStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoodLinksSyncStore.swift; sourceTree = "<group>"; };
 		B20000010000000000000001 /* ShareExtensionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionModel.swift; sourceTree = "<group>"; };
 		B20000010000000000000002 /* ShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareView.swift; sourceTree = "<group>"; };
 		B20000010000000000000003 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
@@ -179,6 +185,8 @@
 				A2000001000000000000000F /* GmailShared.swift */,
 				A20000010000000000000010 /* SharedSessionStore.swift */,
 				A20000010000000000000011 /* GmailDeliveryService.swift */,
+				A2000001000000000000001A /* GoodLinksService.swift */,
+				A2000001000000000000001B /* GoodLinksSyncStore.swift */,
 				A20000010000000000000018 /* AnalyticsClient.swift */,
 				A20000010000000000000019 /* Analytics.plist */,
 			);
@@ -327,6 +335,8 @@
 				A1000001000000000000000D /* GmailShared.swift in Sources */,
 				A1000001000000000000000E /* SharedSessionStore.swift in Sources */,
 				A1000001000000000000000F /* GmailDeliveryService.swift in Sources */,
+				A10000010000000000000017 /* GoodLinksService.swift in Sources */,
+				A10000010000000000000018 /* GoodLinksSyncStore.swift in Sources */,
 				A10000010000000000000011 /* MacControlCenterView.swift in Sources */,
 				A10000010000000000000012 /* MacQueuePane.swift in Sources */,
 				A10000010000000000000013 /* MacSetupSidebar.swift in Sources */,
@@ -350,6 +360,8 @@
 				B10000010000000000000009 /* GmailShared.swift in Sources */,
 				B1000001000000000000000A /* SharedSessionStore.swift in Sources */,
 				B1000001000000000000000B /* GmailDeliveryService.swift in Sources */,
+				B1000001000000000000000F /* GoodLinksService.swift in Sources */,
+				B10000010000000000000010 /* GoodLinksSyncStore.swift in Sources */,
 				B1000001000000000000000D /* AnalyticsClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -467,7 +479,7 @@
 				CODE_SIGN_ENTITLEMENTS = SendMoi/SendMoi.entitlements;
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "SendMoi/SendMoi-macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 120;
+				CURRENT_PROJECT_VERSION = 122;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 289GY9L343;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -498,7 +510,7 @@
 				CODE_SIGN_ENTITLEMENTS = SendMoi/SendMoi.entitlements;
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "SendMoi/SendMoi-macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 120;
+				CURRENT_PROJECT_VERSION = 122;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 289GY9L343;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -530,7 +542,7 @@
 				CODE_SIGN_ENTITLEMENTS = SendMoiShare/SendMoiShare.entitlements;
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "SendMoiShare/SendMoiShare-macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 120;
+				CURRENT_PROJECT_VERSION = 122;
 				DEVELOPMENT_TEAM = 289GY9L343;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = SendMoiShare/Info.plist;
@@ -561,7 +573,7 @@
 				CODE_SIGN_ENTITLEMENTS = SendMoiShare/SendMoiShare.entitlements;
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "SendMoiShare/SendMoiShare-macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 120;
+				CURRENT_PROJECT_VERSION = 122;
 				DEVELOPMENT_TEAM = 289GY9L343;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;

--- a/SendMoi/AppModel.swift
+++ b/SendMoi/AppModel.swift
@@ -6,6 +6,11 @@ final class AppModel: ObservableObject {
     @Published var queuedEmails: [QueuedEmail] = []
     @Published var defaultRecipient = ""
     @Published var shareSheetAutoSendEnabled = true
+    @Published var goodLinksSettings = GoodLinksSettingsStore.load()
+    @Published var syncedGoodLinksJobs: [GoodLinksSyncJob] = GoodLinksSyncStore.load()
+    @Published var isTestingGoodLinks = false
+    @Published var goodLinksConnectionMessage: String?
+    @Published var goodLinksConnectionSucceeded = false
     @Published var session: GmailSession?
     @Published var statusMessage = "Configure Google OAuth, sign in, then queue or send shared items."
     @Published var isBusy = false
@@ -17,8 +22,10 @@ final class AppModel: ObservableObject {
     @Published var analyticsEnabled = false
 
     private let client = GmailAPIClient()
+    private let goodLinksService = GoodLinksService()
     private let monitor = NetworkMonitor()
     private let queueChangeObserver = QueueChangeObserver()
+    private let goodLinksQueueChangeObserver = QueueChangeObserver(notificationName: GoodLinksSyncStore.didChangeNotification)
     private var shouldReprocessQueue = false
     #if os(macOS)
     private var queuePollTimer: Timer?
@@ -37,6 +44,13 @@ final class AppModel: ObservableObject {
             }
         }
         queueChangeObserver.start()
+
+        goodLinksQueueChangeObserver.onChange = { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.handleGoodLinksSyncQueueChange()
+            }
+        }
+        goodLinksQueueChangeObserver.start()
 
         #if os(macOS)
         // Darwin notifications between a Mac Catalyst extension and the main app
@@ -57,6 +71,7 @@ final class AppModel: ObservableObject {
     func startup() async {
         reloadSharedPreferences()
         reloadQueueFromDisk()
+        reloadGoodLinksSyncQueue()
         reloadSessionFromDisk()
 
         isAccountSectionExpanded = session == nil || !GoogleOAuthConfig.isConfigured
@@ -163,6 +178,12 @@ final class AppModel: ObservableObject {
         if wasShowingOnboarding { shouldShowOnboarding = true }
         reloadSessionFromDisk()
         reloadQueueFromDisk()
+        reloadGoodLinksSyncQueue()
+
+        #if os(macOS)
+        await processSyncedGoodLinksQueue()
+        #endif
+
         guard !queuedEmails.isEmpty else { return }
         guard let existingSession = session else {
             statusMessage = "You have queued items. Sign in to Gmail to send them."
@@ -191,12 +212,23 @@ final class AppModel: ObservableObject {
 
             while let next = queuedEmails.last {
                 do {
-                    try await client.sendEmail(using: validSession, item: next)
-                    removeManagedMedia(for: next)
-                    removeQueuedEmail(id: next.id)
-                    RecipientStore.record(next.toEmail)
-                    await AnalyticsClient.shared.send("email_sent", enabled: analyticsEnabled)
-                    statusMessage = "Sent \"\(next.title)\" to \(next.toEmail)."
+                    if next.needsEmailDelivery {
+                        try await client.sendEmail(using: validSession, item: next)
+                        markEmailDelivered(for: next.id)
+                        RecipientStore.record(next.toEmail)
+                        await AnalyticsClient.shared.send("email_sent", enabled: analyticsEnabled)
+                        statusMessage = "Sent \"\(next.title)\" to \(next.toEmail)."
+                    }
+
+                    if queuedEmails.last?.id == next.id,
+                       queuedEmails.last?.needsGoodLinksDelivery == true {
+                        try await deliverGoodLinksCopy(for: queuedEmails.last!)
+                    }
+
+                    if let updated = queuedEmails.last, updated.id == next.id, updated.isFullyDelivered {
+                        removeManagedMedia(for: updated)
+                        removeQueuedEmail(id: updated.id)
+                    }
                 } catch {
                     if let gmailError = error as? GmailAPIError, gmailError.requiresReconnect {
                         requiresGmailReconnect = true
@@ -204,6 +236,9 @@ final class AppModel: ObservableObject {
                         isQueueSectionExpanded = true
                         markFailure(for: next.id, message: gmailError.localizedDescription)
                         statusMessage = "Reconnect Gmail to grant send permission. Queued items will send after you reconnect."
+                    } else if error is GoodLinksError {
+                        markGoodLinksFailure(for: next.id, message: error.localizedDescription)
+                        statusMessage = "Email is done. GoodLinks copy is queued for retry: \(error.localizedDescription)"
                     } else {
                         markFailure(for: next.id, message: error.localizedDescription)
                         statusMessage = "Queued item kept for retry: \(error.localizedDescription)"
@@ -244,13 +279,55 @@ final class AppModel: ObservableObject {
         shareSheetAutoSendEnabled = RecipientStore.loadShareSheetAutoSendEnabled()
     }
 
+    func setGoodLinksSettings(_ settings: GoodLinksSettings) {
+        let previousSettings = goodLinksSettings
+        GoodLinksSettingsStore.save(settings)
+        goodLinksSettings = GoodLinksSettingsStore.load()
+        if previousSettings.apiAddress != goodLinksSettings.apiAddress ||
+            previousSettings.apiToken != goodLinksSettings.apiToken {
+            goodLinksConnectionMessage = nil
+            goodLinksConnectionSucceeded = false
+        }
+    }
+
+    func testGoodLinksConnection() async {
+        guard !isTestingGoodLinks else { return }
+        isTestingGoodLinks = true
+        defer { isTestingGoodLinks = false }
+
+        do {
+            let settings = GoodLinksSettingsStore.load()
+            try await goodLinksService.testLocalAPI(settings: settings)
+            goodLinksConnectionSucceeded = true
+            goodLinksConnectionMessage = "Connection verified."
+            statusMessage = "GoodLinks connection verified."
+            #if os(macOS)
+            await processSyncedGoodLinksQueue()
+            #endif
+        } catch {
+            goodLinksConnectionSucceeded = false
+            goodLinksConnectionMessage = error.localizedDescription
+            statusMessage = "GoodLinks test failed: \(error.localizedDescription)"
+        }
+    }
+
     func retryNow() async {
         let wasShowingOnboarding = shouldShowOnboarding
         reloadSharedPreferences()
         if wasShowingOnboarding { shouldShowOnboarding = true }
         reloadSessionFromDisk()
         reloadQueueFromDisk()
+        reloadGoodLinksSyncQueue()
         await processQueue()
+    }
+
+    func deleteSyncedGoodLinksJob(id: UUID) {
+        do {
+            try GoodLinksSyncStore.remove(id: id)
+            reloadGoodLinksSyncQueue()
+        } catch {
+            statusMessage = "Could not remove GoodLinks sync item: \(error.localizedDescription)"
+        }
     }
 
     func resetSetup() {
@@ -260,10 +337,14 @@ final class AppModel: ObservableObject {
             try KeychainStore.clearSession()
             SharedSessionStore.clear()
             RecipientStore.resetSetup()
+            GoodLinksSettingsStore.reset()
 
             session = nil
             defaultRecipient = RecipientStore.loadDefault()
             shareSheetAutoSendEnabled = RecipientStore.loadShareSheetAutoSendEnabled()
+            goodLinksSettings = GoodLinksSettingsStore.load()
+            goodLinksConnectionMessage = nil
+            goodLinksConnectionSucceeded = false
             isAccountSectionExpanded = true
             shouldShowOnboarding = true
             statusMessage = "Setup reset. Walk through the guide to reconnect Gmail and reconfigure defaults."
@@ -305,6 +386,10 @@ final class AppModel: ObservableObject {
         }
     }
 
+    private func reloadGoodLinksSyncQueue() {
+        syncedGoodLinksJobs = GoodLinksSyncStore.load()
+    }
+
     private func removeQueuedEmail(id: UUID) {
         removeQueuedEmails(ids: [id])
     }
@@ -331,6 +416,29 @@ final class AppModel: ObservableObject {
         }
     }
 
+    private func markEmailDelivered(for id: UUID) {
+        if let index = queuedEmails.firstIndex(where: { $0.id == id }) {
+            queuedEmails[index].emailDeliveredAt = .now
+            queuedEmails[index].lastError = nil
+            persistQueue()
+        }
+    }
+
+    private func markGoodLinksDelivered(for id: UUID) {
+        if let index = queuedEmails.firstIndex(where: { $0.id == id }) {
+            queuedEmails[index].goodLinksDeliveredAt = .now
+            queuedEmails[index].goodLinksLastError = nil
+            persistQueue()
+        }
+    }
+
+    private func markGoodLinksFailure(for id: UUID, message: String) {
+        if let index = queuedEmails.firstIndex(where: { $0.id == id }) {
+            queuedEmails[index].goodLinksLastError = message
+            persistQueue()
+        }
+    }
+
     private func updateReconnectRequirement() {
         requiresGmailReconnect = queuedEmails.contains { item in
             guard let lastError = item.lastError else {
@@ -352,6 +460,7 @@ final class AppModel: ObservableObject {
     private func reloadSharedPreferences() {
         defaultRecipient = RecipientStore.loadDefault()
         shareSheetAutoSendEnabled = RecipientStore.loadShareSheetAutoSendEnabled()
+        goodLinksSettings = GoodLinksSettingsStore.load()
         shouldShowOnboarding = !RecipientStore.loadHasCompletedOnboarding()
         analyticsEnabled = RecipientStore.loadAnalyticsEnabled()
     }
@@ -407,15 +516,72 @@ final class AppModel: ObservableObject {
         }
     }
 
+    private func handleGoodLinksSyncQueueChange() {
+        reloadGoodLinksSyncQueue()
+
+        #if os(macOS)
+        guard syncedGoodLinksJobs.contains(where: { $0.lastError == nil }) else {
+            return
+        }
+
+        Task {
+            await processSyncedGoodLinksQueue()
+        }
+        #endif
+    }
+
     private func removeManagedMedia(for item: QueuedEmail) {
         item.allImageURLStrings.forEach { SharedContainer.removeManagedMediaIfPresent(urlString: $0) }
     }
+
+    private func deliverGoodLinksCopy(for item: QueuedEmail) async throws {
+        let settings = GoodLinksSettingsStore.load()
+        #if os(macOS) || targetEnvironment(macCatalyst)
+        do {
+            try await goodLinksService.saveUsingLocalAPI(item: item, settings: settings)
+            markGoodLinksDelivered(for: item.id)
+            statusMessage = "Saved \"\(item.title)\" to GoodLinks."
+        } catch {
+            markGoodLinksFailure(for: item.id, message: error.localizedDescription)
+            throw error
+        }
+        #elseif os(iOS)
+        do {
+            try GoodLinksSyncStore.append(item: item, settings: settings)
+            reloadGoodLinksSyncQueue()
+            markGoodLinksDelivered(for: item.id)
+            statusMessage = "Queued \"\(item.title)\" for GoodLinks on your Mac."
+        } catch {
+            markGoodLinksFailure(for: item.id, message: error.localizedDescription)
+            throw error
+        }
+        #endif
+    }
+
+    #if os(macOS)
+    private func processSyncedGoodLinksQueue() async {
+        let result = await GoodLinksSyncProcessor.drain(using: goodLinksService)
+        reloadGoodLinksSyncQueue()
+        if result.didSaveJobs {
+            statusMessage = result.savedCount == 1
+                ? "Saved 1 synced GoodLinks item."
+                : "Saved \(result.savedCount) synced GoodLinks items."
+        } else if let lastError = result.lastError, result.remainingCount > 0 {
+            statusMessage = "Synced GoodLinks items will retry later: \(lastError)"
+        }
+    }
+    #endif
 
 }
 
 private final class QueueChangeObserver {
     var onChange: (() -> Void)?
+    private let notificationName: String
     private var isStarted = false
+
+    init(notificationName: String = QueueStore.didChangeNotification) {
+        self.notificationName = notificationName
+    }
 
     func start() {
         guard !isStarted else { return }
@@ -433,7 +599,7 @@ private final class QueueChangeObserver {
                     .takeUnretainedValue()
                 queueObserver.onChange?()
             },
-            QueueStore.didChangeNotification as CFString,
+            notificationName as CFString,
             nil,
             .deliverImmediately
         )
@@ -448,7 +614,7 @@ private final class QueueChangeObserver {
         CFNotificationCenterRemoveObserver(
             center,
             observer,
-            CFNotificationName(rawValue: QueueStore.didChangeNotification as CFString),
+            CFNotificationName(rawValue: notificationName as CFString),
             nil
         )
     }

--- a/SendMoi/ContentView.swift
+++ b/SendMoi/ContentView.swift
@@ -571,6 +571,20 @@ struct ContentView: View {
                     .toggleStyle(.switch)
                 }
 
+                Toggle(isOn: goodLinksBinding(\.isEnabled)) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Also save to GoodLinks")
+                        Text(goodLinksOnboardingDetail)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.switch)
+
+                if model.goodLinksSettings.isEnabled {
+                    onboardingGoodLinksSetupGuide
+                }
+
                 Toggle(isOn: Binding(
                     get: { model.analyticsEnabled },
                     set: { model.setAnalyticsEnabled($0) }
@@ -585,6 +599,67 @@ struct ContentView: View {
                 .toggleStyle(.switch)
             }
         }
+    }
+
+    private var onboardingGoodLinksSetupGuide: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("GoodLinks setup")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+
+            #if os(macOS) || targetEnvironment(macCatalyst)
+            onboardingFeatureRow(
+                iconName: "network",
+                title: "Turn on the local API",
+                detail: "In GoodLinks for Mac, open Settings > API and enable API Server."
+            )
+
+            TextField("API address", text: goodLinksBinding(\.apiAddress))
+                .textFieldStyle(.roundedBorder)
+
+            SecureField("API token", text: goodLinksBinding(\.apiToken))
+                .textFieldStyle(.roundedBorder)
+
+            Button(model.isTestingGoodLinks ? "Testing..." : "Test GoodLinks") {
+                Task { await model.testGoodLinksConnection() }
+            }
+            .buttonStyle(.bordered)
+            .disabled(
+                model.isTestingGoodLinks ||
+                model.goodLinksSettings.apiToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            )
+
+            if let message = model.goodLinksConnectionMessage {
+                Label(
+                    message,
+                    systemImage: model.goodLinksConnectionSucceeded ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+                )
+                .font(.footnote)
+                .foregroundStyle(model.goodLinksConnectionSucceeded ? .green : .orange)
+            }
+            #else
+            onboardingFeatureRow(
+                iconName: "icloud.and.arrow.up.fill",
+                title: "Saved through your Mac",
+                detail: "iPhone and iPad GoodLinks copies sync to SendMoi on your Mac for silent saving."
+            )
+            onboardingFeatureRow(
+                iconName: "macbook",
+                title: "Mac setup required",
+                detail: "On your Mac, paste the token from GoodLinks Settings > API into SendMoi."
+            )
+            #endif
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(onboardingInsetCardFill)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(onboardingCardStroke, lineWidth: 1)
+        )
     }
 
     @ViewBuilder
@@ -1183,6 +1258,10 @@ struct ContentView: View {
             }
             mobileSectionFooter(shareSheetFooterText)
 
+            mobileSectionLabel("GoodLinks")
+            GroupedCard { mobileGoodLinksCardContent }
+            mobileSectionFooter(goodLinksFooterText)
+
             mobileSectionLabel("Analytics")
             GroupedCard {
                 Toggle(isOn: Binding(
@@ -1386,6 +1465,149 @@ struct ContentView: View {
         }
     }
 
+    private var mobileGoodLinksCardContent: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Toggle("Also save to GoodLinks", isOn: goodLinksBinding(\.isEnabled))
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+                .contentShape(Rectangle())
+
+            if model.goodLinksSettings.isEnabled || !model.syncedGoodLinksJobs.isEmpty {
+                Divider().padding(.leading, 20)
+
+                mobileGoodLinksSetupState
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 12)
+            }
+
+            Divider().padding(.leading, 20)
+
+            VStack(alignment: .leading, spacing: 6) {
+                GoodLinksTagsEditor(
+                    tagsText: goodLinksBinding(\.tagsText),
+                    isEnabled: model.goodLinksSettings.isEnabled
+                )
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+
+            Divider().padding(.leading, 20)
+
+            Toggle("Star saved links", isOn: goodLinksBinding(\.starred))
+                .disabled(!model.goodLinksSettings.isEnabled)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+                .contentShape(Rectangle())
+
+            Divider().padding(.leading, 20)
+
+            Toggle("Mark saved links as read", isOn: goodLinksBinding(\.read))
+                .disabled(!model.goodLinksSettings.isEnabled)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+                .contentShape(Rectangle())
+
+            if !model.syncedGoodLinksJobs.isEmpty {
+                Divider().padding(.leading, 20)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    LabeledContent("Mac save queue", value: "\(model.syncedGoodLinksJobs.count) pending")
+                        .font(.subheadline)
+
+                    ForEach(model.syncedGoodLinksJobs) { job in
+                        HStack(alignment: .top, spacing: 10) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(job.title)
+                                    .font(.footnote.weight(.semibold))
+                                    .lineLimit(2)
+                                Text(job.urlString)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                                if let lastError = job.lastError {
+                                    Text(lastError)
+                                        .font(.caption)
+                                        .foregroundStyle(.orange)
+                                        .lineLimit(2)
+                                }
+                            }
+
+                            Spacer(minLength: 8)
+
+                            Button(role: .destructive) {
+                                model.deleteSyncedGoodLinksJob(id: job.id)
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .symbolRenderingMode(.hierarchical)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Remove GoodLinks queue item")
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
+            }
+        }
+    }
+
+    private var mobileGoodLinksSetupState: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(mobileGoodLinksSetupTitle)
+                    .font(.footnote.weight(.semibold))
+                Text(mobileGoodLinksSetupDetail)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        } icon: {
+            Image(systemName: mobileGoodLinksSetupIcon)
+                .foregroundStyle(mobileGoodLinksSetupTint)
+        }
+    }
+
+    private var mobileGoodLinksSetupTitle: String {
+        if model.syncedGoodLinksJobs.contains(where: { $0.lastError != nil }) {
+            return "Mac retry needed"
+        }
+
+        if !model.syncedGoodLinksJobs.isEmpty {
+            return "\(model.syncedGoodLinksJobs.count) waiting for Mac"
+        }
+
+        return "iPhone saves through your Mac"
+    }
+
+    private var mobileGoodLinksSetupDetail: String {
+        if let lastError = model.syncedGoodLinksJobs.compactMap(\.lastError).first {
+            return lastError
+        }
+
+        if !model.syncedGoodLinksJobs.isEmpty {
+            return "Open SendMoi on your Mac after adding the GoodLinks API token there."
+        }
+
+        return "GoodLinks does not expose a silent iOS API, so SendMoi syncs copies to your Mac queue."
+    }
+
+    private var mobileGoodLinksSetupIcon: String {
+        if model.syncedGoodLinksJobs.contains(where: { $0.lastError != nil }) {
+            return "exclamationmark.triangle.fill"
+        }
+
+        if !model.syncedGoodLinksJobs.isEmpty {
+            return "icloud.and.arrow.up.fill"
+        }
+
+        return "info.circle.fill"
+    }
+
+    private var mobileGoodLinksSetupTint: Color {
+        model.syncedGoodLinksJobs.contains(where: { $0.lastError != nil }) ? .orange : .accentColor
+    }
+
     private var mobileQueueCardContent: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
@@ -1426,7 +1648,13 @@ struct ContentView: View {
                         Divider().padding(.leading, 20)
                         VStack(alignment: .leading, spacing: 6) {
                             Text(item.title).font(.headline)
-                            Text("To: \(item.toEmail)").font(.subheadline)
+                            Text(item.needsEmailDelivery ? "To: \(item.toEmail)" : "Email sent to \(item.toEmail)")
+                                .font(.subheadline)
+                            if item.goodLinksEnabled {
+                                Text(item.needsGoodLinksDelivery ? "GoodLinks pending" : "Saved to GoodLinks")
+                                    .font(.subheadline)
+                                    .foregroundStyle(item.needsGoodLinksDelivery ? .orange : .secondary)
+                            }
                             Text(item.urlString).font(.footnote).foregroundStyle(.secondary)
                         }
                         .padding(.horizontal, 20)
@@ -1517,6 +1745,22 @@ struct ContentView: View {
         return "Items shared from other apps stay open so you can review the draft before sending."
     }
 
+    private var goodLinksFooterText: String {
+        #if os(iOS)
+        return "On iPhone and iPad, GoodLinks copies appear in the Mac save queue until your Mac can reach the local GoodLinks API."
+        #else
+        return "On Mac, paste the API address and token from GoodLinks Settings -> API."
+        #endif
+    }
+
+    private var goodLinksOnboardingDetail: String {
+        #if os(iOS)
+        return "Optional bonus copy. On iPhone and iPad this syncs to your Mac for silent GoodLinks saving."
+        #else
+        return "Optional bonus copy using the local GoodLinks API after Gmail sends."
+        #endif
+    }
+
     private var accountSectionFooterText: String {
         if model.requiresGmailReconnect {
             return "Reconnect Gmail to restore send permission for queued items."
@@ -1541,10 +1785,10 @@ struct ContentView: View {
         let count = model.queuedEmails.count
 
         if count == 0 {
-            return "No pending emails"
+            return "No pending items"
         }
 
-        return "\(count) pending email\(count == 1 ? "" : "s")"
+        return "\(count) pending item\(count == 1 ? "" : "s")"
     }
 
     private var queueSummaryDetail: String {
@@ -1566,6 +1810,17 @@ struct ContentView: View {
     private func saveDefaultRecipient() {
         focusedField = nil
         model.setDefaultRecipient(model.defaultRecipient)
+    }
+
+    private func goodLinksBinding<Value>(_ keyPath: WritableKeyPath<GoodLinksSettings, Value>) -> Binding<Value> {
+        Binding(
+            get: { model.goodLinksSettings[keyPath: keyPath] },
+            set: { value in
+                var settings = model.goodLinksSettings
+                settings[keyPath: keyPath] = value
+                model.setGoodLinksSettings(settings)
+            }
+        )
     }
 
     private func saveOnboardingRecipient() {
@@ -1595,6 +1850,176 @@ private struct GroupedCard<Content: View>: View {
     }
 }
 #endif
+
+struct GoodLinksTagsEditor: View {
+    @Binding var tagsText: String
+    let isEnabled: Bool
+
+    @State private var draft = ""
+
+    private var tags: [String] {
+        GoodLinksSettings.normalizedTags(from: tagsText)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Tags")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if tags.isEmpty {
+                Text("No tags")
+                    .font(.footnote)
+                    .foregroundStyle(.tertiary)
+            } else {
+                SendMoiTagFlowLayout(spacing: 8) {
+                    ForEach(tags, id: \.self) { tag in
+                        GoodLinksTagChip(
+                            tag: tag,
+                            isEnabled: isEnabled,
+                            remove: { removeTag(tag) }
+                        )
+                    }
+                }
+            }
+
+            HStack(spacing: 8) {
+                TextField("Add tag", text: $draft)
+                    #if os(iOS)
+                    .textInputAutocapitalization(.never)
+                    #endif
+                    .autocorrectionDisabled()
+                    .disabled(!isEnabled)
+                    .onSubmit(addDraftTags)
+                    .onChange(of: draft) { _, newValue in
+                        if newValue.contains(",") || newValue.last?.isWhitespace == true {
+                            addDraftTags()
+                        }
+                    }
+
+                Button {
+                    addDraftTags()
+                } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .imageScale(.medium)
+                }
+                .buttonStyle(.plain)
+                .disabled(!isEnabled || GoodLinksSettings.normalizedTags(from: draft).isEmpty)
+                .accessibilityLabel("Add GoodLinks tag")
+            }
+        }
+    }
+
+    private func addDraftTags() {
+        let newTags = GoodLinksSettings.normalizedTags(from: draft)
+        guard !newTags.isEmpty else {
+            draft = ""
+            return
+        }
+
+        var combined = tags
+        for tag in newTags where !combined.contains(where: { $0.caseInsensitiveCompare(tag) == .orderedSame }) {
+            combined.append(tag)
+        }
+        setTags(combined)
+        draft = ""
+    }
+
+    private func removeTag(_ tag: String) {
+        setTags(tags.filter { $0 != tag })
+    }
+
+    private func setTags(_ tags: [String]) {
+        tagsText = tags.joined(separator: " ")
+    }
+}
+
+private struct GoodLinksTagChip: View {
+    let tag: String
+    let isEnabled: Bool
+    let remove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(tag)
+                .font(.footnote.weight(.medium))
+                .lineLimit(1)
+
+            Button(action: remove) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .frame(width: 14, height: 14)
+            }
+            .buttonStyle(.plain)
+            .disabled(!isEnabled)
+            .accessibilityLabel("Remove \(tag)")
+        }
+        .padding(.leading, 10)
+        .padding(.trailing, 7)
+        .padding(.vertical, 6)
+        .foregroundStyle(isEnabled ? Color.accentColor : Color.secondary)
+        .background(
+            Capsule()
+                .fill(Color.accentColor.opacity(isEnabled ? 0.13 : 0.07))
+        )
+        .overlay(
+            Capsule()
+                .stroke(Color.accentColor.opacity(isEnabled ? 0.22 : 0.10), lineWidth: 1)
+        )
+    }
+}
+
+private struct SendMoiTagFlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var rowWidth: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var totalWidth: CGFloat = 0
+        var totalHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            let shouldWrap = rowWidth > 0 && rowWidth + spacing + size.width > maxWidth
+            if shouldWrap {
+                totalHeight += rowHeight + spacing
+                totalWidth = max(totalWidth, rowWidth)
+                rowWidth = size.width
+                rowHeight = size.height
+            } else {
+                rowWidth += rowWidth > 0 ? spacing + size.width : size.width
+                rowHeight = max(rowHeight, size.height)
+            }
+        }
+
+        totalHeight += rowHeight
+        totalWidth = max(totalWidth, rowWidth)
+        return CGSize(width: proposal.width ?? totalWidth, height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > bounds.minX && x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+
+            subview.place(
+                at: CGPoint(x: x, y: y),
+                proposal: ProposedViewSize(width: size.width, height: size.height)
+            )
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}
 
 private extension View {
     @ViewBuilder

--- a/SendMoi/Mac/MacQueuePane.swift
+++ b/SendMoi/Mac/MacQueuePane.swift
@@ -11,7 +11,7 @@ struct MacQueuePane: View {
             VStack(alignment: .leading, spacing: 12) {
                 actionButtons
 
-                if displayedQueue.isEmpty {
+                if displayedQueue.isEmpty && displayedSyncedGoodLinksJobs.isEmpty {
                     Text(emptyStateMessage)
                         .font(.footnote)
                         .foregroundStyle(.secondary)
@@ -28,12 +28,26 @@ struct MacQueuePane: View {
                         }
                     )
                 }
+
+                ForEach(displayedSyncedGoodLinksJobs) { job in
+                    MacGoodLinksSyncRow(
+                        job: job,
+                        onRetry: retryQueue,
+                        onDelete: {
+                            model.deleteSyncedGoodLinksJob(id: job.id)
+                        }
+                    )
+                }
             }
         }
     }
 
     private var displayedQueue: [QueuedEmail] {
         model.queuedEmails.reversed()
+    }
+
+    private var displayedSyncedGoodLinksJobs: [GoodLinksSyncJob] {
+        model.syncedGoodLinksJobs
     }
 
     private var retryCandidateID: UUID? {
@@ -43,6 +57,9 @@ struct MacQueuePane: View {
     private var cardSubtitle: String {
         if model.requiresGmailReconnect {
             return "Reconnect Gmail to restore send permission, then retry the queue."
+        }
+        if model.queuedEmails.isEmpty && !model.syncedGoodLinksJobs.isEmpty {
+            return "GoodLinks items from iPhone are waiting for the local Mac API."
         }
         if model.queuedEmails.isEmpty {
             return "Shared items that need attention will appear here."
@@ -103,11 +120,70 @@ struct MacQueuePane: View {
     }
 
     private var showsRetryAllButton: Bool {
-        !model.queuedEmails.isEmpty && model.session != nil && !model.requiresGmailReconnect
+        !model.syncedGoodLinksJobs.isEmpty ||
+            (!model.queuedEmails.isEmpty && model.session != nil && !model.requiresGmailReconnect)
     }
 
     private func retryQueue() {
         Task { await model.retryNow() }
+    }
+}
+
+private struct MacGoodLinksSyncRow: View {
+    let job: GoodLinksSyncJob
+    let onRetry: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(job.title)
+                        .font(.headline)
+
+                    LabeledContent("GoodLinks", value: goodLinksStatus)
+                        .font(.subheadline)
+                        .foregroundStyle(.orange)
+
+                    Text(job.urlString)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+
+                    if let lastError = job.lastError {
+                        Text(lastError)
+                            .font(.footnote)
+                            .foregroundStyle(.orange)
+                    }
+                }
+
+                Spacer(minLength: 12)
+
+                VStack(alignment: .trailing, spacing: 10) {
+                    Button("Retry Now", action: onRetry)
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+
+                    Button(role: .destructive, action: onDelete) {
+                        Label("Delete", systemImage: "trash")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+
+            Divider()
+        }
+        .padding(12)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(.quaternary)
+        )
+    }
+
+    private var goodLinksStatus: String {
+        job.lastError == nil ? "Waiting for Mac API" : "Retry needed"
     }
 }
 
@@ -125,8 +201,17 @@ private struct MacQueueRow: View {
                     Text(item.title)
                         .font(.headline)
 
-                    LabeledContent("Recipient", value: item.toEmail)
+                    LabeledContent(item.needsEmailDelivery ? "Recipient" : "Email sent", value: item.toEmail)
                         .font(.subheadline)
+
+                    if item.goodLinksEnabled {
+                        LabeledContent(
+                            "GoodLinks",
+                            value: item.needsGoodLinksDelivery ? "Pending" : "Saved"
+                        )
+                        .font(.subheadline)
+                        .foregroundStyle(item.needsGoodLinksDelivery ? .orange : .secondary)
+                    }
 
                     if let sourceLabel {
                         LabeledContent("Source", value: sourceLabel)
@@ -140,6 +225,12 @@ private struct MacQueueRow: View {
 
                     if let lastError = item.lastError {
                         Text(lastError)
+                            .font(.footnote)
+                            .foregroundStyle(.orange)
+                    }
+
+                    if let goodLinksLastError = item.goodLinksLastError {
+                        Text(goodLinksLastError)
                             .font(.footnote)
                             .foregroundStyle(.orange)
                     }

--- a/SendMoi/Mac/MacSetupSidebar.swift
+++ b/SendMoi/Mac/MacSetupSidebar.swift
@@ -19,6 +19,7 @@ struct MacSetupSidebar: View {
             gmailCard
             recipientCard
             shareBehaviorCard
+            goodLinksCard
             analyticsCard
             setupCard
         }
@@ -128,6 +129,54 @@ struct MacSetupSidebar: View {
         }
     }
 
+    private var goodLinksCard: some View {
+        MacSidebarCard(
+            title: "GoodLinks",
+            subtitle: goodLinksSubtitle
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                Toggle(isOn: goodLinksBinding(\.isEnabled)) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Also save to GoodLinks")
+                        Text("Uses the local GoodLinks API for shares started on this Mac.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .toggleStyle(.switch)
+
+                goodLinksSetupState
+
+                TextField("API address", text: goodLinksBinding(\.apiAddress))
+                    .textFieldStyle(.roundedBorder)
+
+                SecureField("API token", text: goodLinksBinding(\.apiToken))
+                    .textFieldStyle(.roundedBorder)
+
+                goodLinksSetupGuide
+
+                GoodLinksTagsEditor(
+                    tagsText: goodLinksBinding(\.tagsText),
+                    isEnabled: true
+                )
+
+                Toggle("Star saved links", isOn: goodLinksBinding(\.starred))
+
+                Toggle("Mark saved links as read", isOn: goodLinksBinding(\.read))
+
+                Button(goodLinksTestButtonTitle) {
+                    Task { await model.testGoodLinksConnection() }
+                }
+                .buttonStyle(.bordered)
+                .disabled(
+                    model.isBusy ||
+                    model.isTestingGoodLinks ||
+                    model.goodLinksSettings.apiToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                )
+            }
+        }
+    }
+
     private var analyticsCard: some View {
         MacSidebarCard(
             title: "Analytics",
@@ -176,6 +225,17 @@ struct MacSetupSidebar: View {
         model.setDefaultRecipient(model.defaultRecipient)
     }
 
+    private func goodLinksBinding<Value>(_ keyPath: WritableKeyPath<GoodLinksSettings, Value>) -> Binding<Value> {
+        Binding(
+            get: { model.goodLinksSettings[keyPath: keyPath] },
+            set: { value in
+                var settings = model.goodLinksSettings
+                settings[keyPath: keyPath] = value
+                model.setGoodLinksSettings(settings)
+            }
+        )
+    }
+
     private func clearInitialRecipientFocus() {
         focusedField = nil
         #if os(macOS)
@@ -194,6 +254,167 @@ struct MacSetupSidebar: View {
             return "SendMoi needs Gmail to send queued items."
         }
         return "Ready for queued delivery on this Mac."
+    }
+
+    private var goodLinksSubtitle: String {
+        if !model.syncedGoodLinksJobs.isEmpty {
+            return "Paste the local API token so this Mac can save iPhone GoodLinks items."
+        }
+
+        if model.goodLinksSettings.isEnabled {
+            return "Save a bonus copy to GoodLinks after Gmail sends."
+        }
+
+        return "Optional. Gmail remains the required delivery path."
+    }
+
+    private var goodLinksSetupState: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(goodLinksSetupStateTitle)
+                    .font(.footnote.weight(.semibold))
+                Text(goodLinksSetupStateDetail)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        } icon: {
+            Image(systemName: goodLinksSetupStateIcon)
+                .foregroundStyle(goodLinksSetupStateTint)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(goodLinksSetupStateTint.opacity(0.10))
+        )
+    }
+
+    private var goodLinksSetupGuide: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("GoodLinks setup")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+
+            goodLinksSetupStep("1", "In GoodLinks for Mac, open Settings > API and turn on API Server.")
+            goodLinksSetupStep("2", "Paste the Address and API Token from GoodLinks into SendMoi.")
+            goodLinksSetupStep("3", "Test the connection. Pending iPhone items retry after a successful test.")
+        }
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+    }
+
+    private func goodLinksSetupStep(_ number: String, _ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(number)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(.white)
+                .frame(width: 18, height: 18)
+                .background(Circle().fill(Color.accentColor))
+            Text(text)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var goodLinksTestButtonTitle: String {
+        if model.isTestingGoodLinks {
+            return "Testing..."
+        }
+
+        if !model.syncedGoodLinksJobs.isEmpty {
+            return "Test & Retry Queue"
+        }
+
+        return "Test Connection"
+    }
+
+    private var goodLinksSetupStateTitle: String {
+        if model.goodLinksConnectionSucceeded {
+            return "GoodLinks is ready"
+        }
+
+        if model.goodLinksConnectionMessage != nil {
+            return "GoodLinks needs attention"
+        }
+
+        if goodLinksAddressIsMissing {
+            return "Add the API address"
+        }
+
+        if goodLinksTokenIsMissing {
+            return "Paste the API token"
+        }
+
+        if !model.syncedGoodLinksJobs.isEmpty {
+            return "Pending iPhone saves are waiting"
+        }
+
+        if model.goodLinksSettings.isEnabled {
+            return "Ready to test"
+        }
+
+        return "Configured for later"
+    }
+
+    private var goodLinksSetupStateDetail: String {
+        if let message = model.goodLinksConnectionMessage {
+            return message
+        }
+
+        if goodLinksAddressIsMissing {
+            return "Use the local address shown in GoodLinks Settings > API, usually http://localhost:9428."
+        }
+
+        if goodLinksTokenIsMissing {
+            return "SendMoi cannot save to GoodLinks until this Mac has the token from GoodLinks Settings > API."
+        }
+
+        if !model.syncedGoodLinksJobs.isEmpty {
+            return "The Mac will use this API token even if Mac-origin GoodLinks copies are off."
+        }
+
+        if model.goodLinksSettings.isEnabled {
+            return "Test the local API before relying on GoodLinks copies."
+        }
+
+        return "The token stays saved for iPhone queue processing and future Mac saves."
+    }
+
+    private var goodLinksSetupStateIcon: String {
+        if model.goodLinksConnectionSucceeded {
+            return "checkmark.circle.fill"
+        }
+
+        if model.goodLinksConnectionMessage != nil || goodLinksAddressIsMissing || goodLinksTokenIsMissing {
+            return "exclamationmark.triangle.fill"
+        }
+
+        if !model.syncedGoodLinksJobs.isEmpty {
+            return "arrow.triangle.2.circlepath.circle.fill"
+        }
+
+        return "info.circle.fill"
+    }
+
+    private var goodLinksSetupStateTint: Color {
+        if model.goodLinksConnectionSucceeded {
+            return .green
+        }
+
+        if model.goodLinksConnectionMessage != nil || goodLinksAddressIsMissing || goodLinksTokenIsMissing {
+            return .orange
+        }
+
+        return .accentColor
+    }
+
+    private var goodLinksAddressIsMissing: Bool {
+        model.goodLinksSettings.apiAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var goodLinksTokenIsMissing: Bool {
+        model.goodLinksSettings.apiToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var gmailIcon: String {

--- a/SendMoi/Models.swift
+++ b/SendMoi/Models.swift
@@ -426,10 +426,43 @@ struct QueuedEmail: Codable, Identifiable, Equatable {
     let previewImageURLString: String?
     let additionalImageURLStrings: [String]?
     let createdAt: Date
+    var emailDeliveredAt: Date?
+    var goodLinksEnabled: Bool
+    var goodLinksDeliveredAt: Date?
+    var goodLinksLastError: String?
     var lastError: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case toEmail
+        case title
+        case excerpt
+        case summary
+        case urlString
+        case previewImageURLString
+        case additionalImageURLStrings
+        case createdAt
+        case emailDeliveredAt
+        case goodLinksEnabled
+        case goodLinksDeliveredAt
+        case goodLinksLastError
+        case lastError
+    }
 
     var allImageURLStrings: [String] {
         combinedImageURLStrings(primary: previewImageURLString, additional: additionalImageURLStrings ?? [])
+    }
+
+    var needsEmailDelivery: Bool {
+        emailDeliveredAt == nil
+    }
+
+    var needsGoodLinksDelivery: Bool {
+        goodLinksEnabled && goodLinksDeliveredAt == nil
+    }
+
+    var isFullyDelivered: Bool {
+        !needsEmailDelivery && !needsGoodLinksDelivery
     }
 
     init(
@@ -442,6 +475,10 @@ struct QueuedEmail: Codable, Identifiable, Equatable {
         previewImageURLString: String? = nil,
         additionalImageURLStrings: [String]? = nil,
         createdAt: Date = .now,
+        emailDeliveredAt: Date? = nil,
+        goodLinksEnabled: Bool = false,
+        goodLinksDeliveredAt: Date? = nil,
+        goodLinksLastError: String? = nil,
         lastError: String? = nil
     ) {
         self.id = id
@@ -453,7 +490,29 @@ struct QueuedEmail: Codable, Identifiable, Equatable {
         self.previewImageURLString = previewImageURLString
         self.additionalImageURLStrings = additionalImageURLStrings
         self.createdAt = createdAt
+        self.emailDeliveredAt = emailDeliveredAt
+        self.goodLinksEnabled = goodLinksEnabled
+        self.goodLinksDeliveredAt = goodLinksDeliveredAt
+        self.goodLinksLastError = goodLinksLastError
         self.lastError = lastError
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        toEmail = try container.decode(String.self, forKey: .toEmail)
+        title = try container.decode(String.self, forKey: .title)
+        excerpt = try container.decode(String.self, forKey: .excerpt)
+        summary = try container.decodeIfPresent(String.self, forKey: .summary)
+        urlString = try container.decode(String.self, forKey: .urlString)
+        previewImageURLString = try container.decodeIfPresent(String.self, forKey: .previewImageURLString)
+        additionalImageURLStrings = try container.decodeIfPresent([String].self, forKey: .additionalImageURLStrings)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        emailDeliveredAt = try container.decodeIfPresent(Date.self, forKey: .emailDeliveredAt)
+        goodLinksEnabled = try container.decodeIfPresent(Bool.self, forKey: .goodLinksEnabled) ?? false
+        goodLinksDeliveredAt = try container.decodeIfPresent(Date.self, forKey: .goodLinksDeliveredAt)
+        goodLinksLastError = try container.decodeIfPresent(String.self, forKey: .goodLinksLastError)
+        lastError = try container.decodeIfPresent(String.self, forKey: .lastError)
     }
 }
 

--- a/SendMoi/SendMoi-macOS.entitlements
+++ b/SendMoi/SendMoi-macOS.entitlements
@@ -8,6 +8,8 @@
 	<array>
 		<string>group.com.niederme.sendmoi</string>
 	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)com.niederme.SendMoi</string>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>

--- a/SendMoi/SendMoi.entitlements
+++ b/SendMoi/SendMoi.entitlements
@@ -6,5 +6,7 @@
 	<array>
 		<string>group.com.niederme.sendmoi</string>
 	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)com.niederme.SendMoi</string>
 </dict>
 </plist>

--- a/SendMoi/Services/GoodLinksService.swift
+++ b/SendMoi/Services/GoodLinksService.swift
@@ -1,0 +1,335 @@
+import Foundation
+
+enum GoodLinksError: LocalizedError {
+    case disabled
+    case notConfigured
+    case invalidURL
+    case invalidCallbackURL
+    case openURLUnavailable
+    case localAPIUnavailable
+    case api(String)
+    case transport(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .disabled:
+            return "GoodLinks saving is turned off."
+        case .notConfigured:
+            return "Add the GoodLinks API address and token before saving to GoodLinks."
+        case .invalidURL:
+            return "GoodLinks needs a valid http or https URL."
+        case .invalidCallbackURL:
+            return "Could not build the GoodLinks save URL."
+        case .openURLUnavailable:
+            return "GoodLinks could not be opened on this device."
+        case .localAPIUnavailable:
+            return "Silent GoodLinks saving requires the local GoodLinks API on a Mac."
+        case .api(let message):
+            return message
+        case .transport(let error):
+            return error.localizedDescription
+        }
+    }
+}
+
+struct GoodLinksSettings: Equatable {
+    var isEnabled: Bool
+    var apiAddress: String
+    var apiToken: String
+    var tagsText: String
+    var starred: Bool
+    var read: Bool
+
+    static let defaultAPIAddress = "http://localhost:9428"
+    static let defaultTagsText = "sendmoi"
+
+    var tags: [String] {
+        Self.normalizedTags(from: tagsText)
+    }
+
+    static func normalizedTags(from tagsText: String) -> [String] {
+        tagsText
+            .split(whereSeparator: { character in
+                character == "," || character.isWhitespace || character.isNewline
+            })
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .map { tag in
+                tag.hasPrefix("#") ? String(tag.dropFirst()) : tag
+            }
+            .filter { !$0.isEmpty }
+    }
+}
+
+enum GoodLinksSettingsStore {
+    private static let enabledKey = "goodLinks.enabled"
+    private static let apiAddressKey = "goodLinks.apiAddress"
+    private static let apiTokenKey = "goodLinks.apiToken"
+    private static let tagsKey = "goodLinks.tags"
+    private static let tagsCustomizedKey = "goodLinks.tagsCustomized"
+    private static let starredKey = "goodLinks.starred"
+    private static let readKey = "goodLinks.read"
+
+    static func load() -> GoodLinksSettings {
+        let defaults = SharedContainer.sharedDefaults
+        defaults.synchronize()
+        let storedTagsText = defaults.string(forKey: tagsKey)
+        let hasCustomizedTags = defaults.bool(forKey: tagsCustomizedKey)
+        let resolvedTagsText: String
+        if storedTagsText == nil ||
+            (storedTagsText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true && !hasCustomizedTags) {
+            resolvedTagsText = GoodLinksSettings.defaultTagsText
+        } else {
+            resolvedTagsText = storedTagsText ?? GoodLinksSettings.defaultTagsText
+        }
+
+        return GoodLinksSettings(
+            isEnabled: defaults.bool(forKey: enabledKey),
+            apiAddress: defaults.string(forKey: apiAddressKey) ?? GoodLinksSettings.defaultAPIAddress,
+            apiToken: defaults.string(forKey: apiTokenKey) ?? "",
+            tagsText: resolvedTagsText,
+            starred: defaults.bool(forKey: starredKey),
+            read: defaults.bool(forKey: readKey)
+        )
+    }
+
+    static func save(_ settings: GoodLinksSettings) {
+        let defaults = SharedContainer.sharedDefaults
+        defaults.set(settings.isEnabled, forKey: enabledKey)
+        defaults.set(settings.apiAddress.trimmingCharacters(in: .whitespacesAndNewlines), forKey: apiAddressKey)
+        defaults.set(settings.apiToken.trimmingCharacters(in: .whitespacesAndNewlines), forKey: apiTokenKey)
+        defaults.set(settings.tagsText.trimmingCharacters(in: .whitespacesAndNewlines), forKey: tagsKey)
+        defaults.set(true, forKey: tagsCustomizedKey)
+        defaults.set(settings.starred, forKey: starredKey)
+        defaults.set(settings.read, forKey: readKey)
+        defaults.synchronize()
+    }
+
+    static func reset() {
+        let defaults = SharedContainer.sharedDefaults
+        defaults.removeObject(forKey: enabledKey)
+        defaults.removeObject(forKey: apiAddressKey)
+        defaults.removeObject(forKey: apiTokenKey)
+        defaults.removeObject(forKey: tagsKey)
+        defaults.removeObject(forKey: tagsCustomizedKey)
+        defaults.removeObject(forKey: starredKey)
+        defaults.removeObject(forKey: readKey)
+        defaults.synchronize()
+    }
+}
+
+final class GoodLinksService {
+    private let decoder = JSONDecoder()
+
+    func testLocalAPI(settings: GoodLinksSettings) async throws {
+        let url = try apiURL(settings: settings, path: "links", requiresEnabledSetting: false)
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 5
+        request.setValue("Bearer \(settings.apiToken.trimmingCharacters(in: .whitespacesAndNewlines))", forHTTPHeaderField: "Authorization")
+        _ = try await send(request)
+    }
+
+    func saveUsingLocalAPI(item: QueuedEmail, settings: GoodLinksSettings) async throws {
+        let url = try apiURL(settings: settings, path: "links")
+        let payload = GoodLinksSaveRequest(
+            url: try validatedHTTPURLString(item.urlString),
+            title: clipped(cleaned(item.title), limit: 200),
+            summary: clipped(preferredSummary(from: item), limit: 400),
+            tags: settings.tags.isEmpty ? nil : settings.tags,
+            read: settings.read ? true : nil,
+            starred: settings.starred ? true : nil
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 10
+        request.setValue("Bearer \(settings.apiToken.trimmingCharacters(in: .whitespacesAndNewlines))", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(payload)
+        _ = try await send(request)
+    }
+
+    func saveUsingLocalAPI(job: GoodLinksSyncJob, settings: GoodLinksSettings) async throws {
+        let url = try apiURL(settings: settings, path: "links", requiresEnabledSetting: false)
+        let payload = GoodLinksSaveRequest(
+            url: try validatedHTTPURLString(job.urlString),
+            title: clipped(cleaned(job.title), limit: 200),
+            summary: clipped(preferredSummary(summary: job.summary, excerpt: job.excerpt), limit: 400),
+            tags: job.tags.isEmpty ? nil : job.tags,
+            read: job.read ? true : nil,
+            starred: job.starred ? true : nil
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 10
+        request.setValue("Bearer \(settings.apiToken.trimmingCharacters(in: .whitespacesAndNewlines))", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(payload)
+        _ = try await send(request)
+    }
+
+    func callbackURL(item: QueuedEmail, settings: GoodLinksSettings) throws -> URL {
+        var components = URLComponents()
+        components.scheme = "goodlinks"
+        components.host = "x-callback-url"
+        components.path = "/save"
+
+        var queryItems = [
+            URLQueryItem(name: "quick", value: "1"),
+            URLQueryItem(name: "url", value: try validatedHTTPURLString(item.urlString))
+        ]
+
+        let title = clipped(cleaned(item.title), limit: 200)
+        if !title.isEmpty {
+            queryItems.append(URLQueryItem(name: "title", value: title))
+        }
+
+        let summary = clipped(preferredSummary(from: item), limit: 400)
+        if !summary.isEmpty {
+            queryItems.append(URLQueryItem(name: "summary", value: summary))
+        }
+
+        if !settings.tags.isEmpty {
+            queryItems.append(URLQueryItem(name: "tags", value: settings.tags.joined(separator: " ")))
+        }
+
+        if settings.starred {
+            queryItems.append(URLQueryItem(name: "starred", value: "1"))
+        }
+
+        if settings.read {
+            queryItems.append(URLQueryItem(name: "read", value: "1"))
+        }
+
+        components.queryItems = queryItems
+        guard let url = components.url else {
+            throw GoodLinksError.invalidCallbackURL
+        }
+        return url
+    }
+
+    private func apiURL(
+        settings: GoodLinksSettings,
+        path: String,
+        requiresEnabledSetting: Bool = true
+    ) throws -> URL {
+        guard !requiresEnabledSetting || settings.isEnabled else {
+            throw GoodLinksError.disabled
+        }
+
+        let address = settings.apiAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+        let token = settings.apiToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !address.isEmpty, !token.isEmpty else {
+            throw GoodLinksError.notConfigured
+        }
+
+        guard let baseURL = URL(string: address) else {
+            throw GoodLinksError.notConfigured
+        }
+
+        return baseURL
+            .appendingPathComponent("api", isDirectory: true)
+            .appendingPathComponent("v1", isDirectory: true)
+            .appendingPathComponent(path, isDirectory: false)
+    }
+
+    private func send(_ request: URLRequest) async throws -> Data {
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw GoodLinksError.api("GoodLinks returned an unexpected response.")
+            }
+
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                if let errorResponse = try? decoder.decode(GoodLinksAPIErrorResponse.self, from: data) {
+                    throw GoodLinksError.api(errorResponse.error)
+                }
+                throw GoodLinksError.api("GoodLinks returned status \(httpResponse.statusCode).")
+            }
+
+            return data
+        } catch let error as GoodLinksError {
+            throw error
+        } catch {
+            throw GoodLinksError.transport(error)
+        }
+    }
+
+    private func validatedHTTPURLString(_ urlString: String) throws -> String {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https" else {
+            throw GoodLinksError.invalidURL
+        }
+        return trimmed
+    }
+
+    private func preferredSummary(from item: QueuedEmail) -> String {
+        preferredSummary(summary: item.summary, excerpt: item.excerpt)
+    }
+
+    private func preferredSummary(summary: String?, excerpt: String) -> String {
+        if let summary = summary?.trimmingCharacters(in: .whitespacesAndNewlines), !summary.isEmpty {
+            return cleaned(summary)
+        }
+        return cleaned(excerpt)
+    }
+
+    private func cleaned(_ value: String) -> String {
+        value
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    private func clipped(_ value: String, limit: Int) -> String {
+        guard value.count > limit else {
+            return value
+        }
+        return String(value.prefix(limit)).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private struct GoodLinksSaveRequest: Encodable {
+    let url: String
+    let title: String?
+    let summary: String?
+    let tags: [String]?
+    let read: Bool?
+    let starred: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case url
+        case title
+        case summary
+        case tags
+        case read
+        case starred
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(url, forKey: .url)
+        if let title, !title.isEmpty {
+            try container.encode(title, forKey: .title)
+        }
+        if let summary, !summary.isEmpty {
+            try container.encode(summary, forKey: .summary)
+        }
+        if let tags, !tags.isEmpty {
+            try container.encode(tags, forKey: .tags)
+        }
+        if let read {
+            try container.encode(read, forKey: .read)
+        }
+        if let starred {
+            try container.encode(starred, forKey: .starred)
+        }
+    }
+}
+
+private struct GoodLinksAPIErrorResponse: Decodable {
+    let error: String
+}

--- a/SendMoi/Services/GoodLinksSyncStore.swift
+++ b/SendMoi/Services/GoodLinksSyncStore.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+struct GoodLinksSyncJob: Codable, Identifiable, Equatable {
+    var id: UUID
+    var title: String
+    var excerpt: String
+    var summary: String?
+    var urlString: String
+    var tags: [String]
+    var starred: Bool
+    var read: Bool
+    var createdAt: Date
+    var attemptCount: Int
+    var lastError: String?
+
+    init(item: QueuedEmail, settings: GoodLinksSettings) {
+        id = item.id
+        title = item.title
+        excerpt = item.excerpt
+        summary = item.summary
+        urlString = item.urlString
+        tags = settings.tags
+        starred = settings.starred
+        read = settings.read
+        createdAt = .now
+        attemptCount = 0
+        lastError = nil
+    }
+}
+
+enum GoodLinksSyncStore {
+    static let didChangeNotification = "com.niederme.SendMoi.goodLinksSyncQueueDidChange"
+
+    private static let queueKey = "goodLinks.syncedQueue.v1"
+    private static let store = NSUbiquitousKeyValueStore.default
+
+    static func load() -> [GoodLinksSyncJob] {
+        store.synchronize()
+        guard let data = store.data(forKey: queueKey),
+              let queue = try? JSONDecoder().decode([GoodLinksSyncJob].self, from: data) else {
+            return []
+        }
+        return queue
+    }
+
+    static func append(item: QueuedEmail, settings: GoodLinksSettings) throws {
+        try append(GoodLinksSyncJob(item: item, settings: settings))
+    }
+
+    static func append(_ job: GoodLinksSyncJob) throws {
+        var queue = load()
+        if let index = queue.firstIndex(where: { $0.id == job.id || $0.urlString == job.urlString }) {
+            queue[index] = job
+        } else {
+            queue.insert(job, at: 0)
+        }
+        try save(queue)
+    }
+
+    static func remove(id: UUID) throws {
+        var queue = load()
+        queue.removeAll { $0.id == id }
+        try save(queue)
+    }
+
+    static func recordFailure(id: UUID, message: String) throws {
+        var queue = load()
+        guard let index = queue.firstIndex(where: { $0.id == id }) else { return }
+        queue[index].attemptCount += 1
+        queue[index].lastError = message
+        try save(queue)
+    }
+
+    private static func save(_ queue: [GoodLinksSyncJob]) throws {
+        let data = try JSONEncoder().encode(queue)
+        store.set(data, forKey: queueKey)
+        store.synchronize()
+        notifyQueueDidChange()
+    }
+
+    private static func notifyQueueDidChange() {
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(rawValue: didChangeNotification as CFString),
+            nil,
+            nil,
+            true
+        )
+    }
+}
+
+struct GoodLinksSyncDrainResult: Equatable {
+    var savedCount: Int
+    var remainingCount: Int
+    var lastError: String?
+
+    var didSaveJobs: Bool {
+        savedCount > 0
+    }
+}
+
+enum GoodLinksSyncProcessor {
+    static func drain(using service: GoodLinksService = GoodLinksService()) async -> GoodLinksSyncDrainResult {
+        let jobs = GoodLinksSyncStore.load()
+        guard !jobs.isEmpty else {
+            return GoodLinksSyncDrainResult(savedCount: 0, remainingCount: 0, lastError: nil)
+        }
+
+        let settings = GoodLinksSettingsStore.load()
+        var savedCount = 0
+        for job in jobs.reversed() {
+            do {
+                try await service.saveUsingLocalAPI(job: job, settings: settings)
+                try GoodLinksSyncStore.remove(id: job.id)
+                savedCount += 1
+            } catch {
+                try? GoodLinksSyncStore.recordFailure(id: job.id, message: error.localizedDescription)
+                return GoodLinksSyncDrainResult(
+                    savedCount: savedCount,
+                    remainingCount: GoodLinksSyncStore.load().count,
+                    lastError: error.localizedDescription
+                )
+            }
+        }
+
+        return GoodLinksSyncDrainResult(savedCount: savedCount, remainingCount: 0, lastError: nil)
+    }
+}

--- a/SendMoiShare/SendMoiShare-macOS.entitlements
+++ b/SendMoiShare/SendMoiShare-macOS.entitlements
@@ -8,6 +8,8 @@
 	<array>
 		<string>group.com.niederme.sendmoi</string>
 	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)com.niederme.SendMoi</string>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>

--- a/SendMoiShare/SendMoiShare.entitlements
+++ b/SendMoiShare/SendMoiShare.entitlements
@@ -6,5 +6,7 @@
 	<array>
 		<string>group.com.niederme.sendmoi</string>
 	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)com.niederme.SendMoi</string>
 </dict>
 </plist>

--- a/SendMoiShare/ShareExtensionModel.swift
+++ b/SendMoiShare/ShareExtensionModel.swift
@@ -53,6 +53,7 @@ final class ShareExtensionModel: ObservableObject {
 
     private weak var extensionContextRef: NSExtensionContext?
     private let deliveryService = GmailDeliveryService()
+    private let goodLinksService = GoodLinksService()
     private var previewTask: Task<Void, Never>?
     private var sendTask: Task<Void, Never>?
     private var deliveryTimeoutTask: Task<Void, Never>?
@@ -297,6 +298,10 @@ final class ShareExtensionModel: ObservableObject {
         from draft: ShareDraft,
         id: UUID = UUID(),
         createdAt: Date = .now,
+        emailDeliveredAt: Date? = nil,
+        goodLinksEnabled: Bool = GoodLinksSettingsStore.load().isEnabled,
+        goodLinksDeliveredAt: Date? = nil,
+        goodLinksLastError: String? = nil,
         lastError: String? = nil
     ) -> QueuedEmail {
         QueuedEmail(
@@ -309,6 +314,10 @@ final class ShareExtensionModel: ObservableObject {
             previewImageURLString: draft.previewImageURLString,
             additionalImageURLStrings: draft.additionalImageURLStrings.isEmpty ? nil : draft.additionalImageURLStrings,
             createdAt: createdAt,
+            emailDeliveredAt: emailDeliveredAt,
+            goodLinksEnabled: goodLinksEnabled,
+            goodLinksDeliveredAt: goodLinksDeliveredAt,
+            goodLinksLastError: goodLinksLastError,
             lastError: lastError
         )
     }
@@ -502,6 +511,10 @@ final class ShareExtensionModel: ObservableObject {
         }
 
         do {
+            #if os(macOS) || targetEnvironment(macCatalyst)
+            await processSyncedGoodLinksQueueIfPossible()
+            #endif
+
             guard let session = try SharedSessionStore.load() else {
                 // No session — queue for main app delivery and show reconnect prompt.
                 try QueueStore.append(refreshedItem)
@@ -519,8 +532,33 @@ final class ShareExtensionModel: ObservableObject {
             pendingAutoSendItem = nil  // item sent — don't queue it if the timeout fires during flush
             Task { await AnalyticsClient.shared.send("email_sent", params: ["source": "share_sheet"], enabled: analyticsEnabled) }
 
+            do {
+                try await saveGoodLinksCopyIfNeeded(for: refreshedItem)
+            } catch {
+                let pendingGoodLinksItem = QueuedEmail(
+                    id: refreshedItem.id,
+                    toEmail: refreshedItem.toEmail,
+                    title: refreshedItem.title,
+                    excerpt: refreshedItem.excerpt,
+                    summary: refreshedItem.summary,
+                    urlString: refreshedItem.urlString,
+                    previewImageURLString: refreshedItem.previewImageURLString,
+                    additionalImageURLStrings: refreshedItem.additionalImageURLStrings,
+                    createdAt: refreshedItem.createdAt,
+                    emailDeliveredAt: .now,
+                    goodLinksEnabled: refreshedItem.goodLinksEnabled,
+                    goodLinksDeliveredAt: nil,
+                    goodLinksLastError: error.localizedDescription,
+                    lastError: nil
+                )
+                try? QueueStore.append(pendingGoodLinksItem)
+            }
+
             // Flush any backlog the main app left behind (best-effort).
             try? await flushQueuedEmails(using: validSession)
+            #if os(macOS) || targetEnvironment(macCatalyst)
+            await processSyncedGoodLinksQueueIfPossible()
+            #endif
             try SharedSessionStore.save(validSession)
             extensionContextRef?.completeRequest(returningItems: nil, completionHandler: nil)
             return refreshedItem
@@ -553,7 +591,16 @@ final class ShareExtensionModel: ObservableObject {
         let draft = draftApplyingPendingPreview(to: currentDraft())
         guard draft.isValidForQueue else { return item }
 
-        let enriched = makeQueuedEmail(from: draft, id: item.id, createdAt: item.createdAt, lastError: item.lastError)
+        let enriched = makeQueuedEmail(
+            from: draft,
+            id: item.id,
+            createdAt: item.createdAt,
+            emailDeliveredAt: item.emailDeliveredAt,
+            goodLinksEnabled: item.goodLinksEnabled,
+            goodLinksDeliveredAt: item.goodLinksDeliveredAt,
+            goodLinksLastError: item.goodLinksLastError,
+            lastError: item.lastError
+        )
         return enriched != item ? enriched : item
     }
 
@@ -730,6 +777,10 @@ final class ShareExtensionModel: ObservableObject {
             from: updatedDraft,
             id: queuedPreviewEnrichmentItem.id,
             createdAt: queuedPreviewEnrichmentItem.createdAt,
+            emailDeliveredAt: queuedPreviewEnrichmentItem.emailDeliveredAt,
+            goodLinksEnabled: queuedPreviewEnrichmentItem.goodLinksEnabled,
+            goodLinksDeliveredAt: queuedPreviewEnrichmentItem.goodLinksDeliveredAt,
+            goodLinksLastError: queuedPreviewEnrichmentItem.goodLinksLastError,
             lastError: queuedPreviewEnrichmentItem.lastError
         )
 
@@ -758,15 +809,30 @@ final class ShareExtensionModel: ObservableObject {
         let queuedItem = queue[index]
 
         do {
-            try await deliveryService.sendEmail(using: session, item: queuedItem)
-            removeManagedMedia(for: queuedItem)
-            queue.remove(at: index)
+            if queuedItem.needsEmailDelivery {
+                try await deliveryService.sendEmail(using: session, item: queuedItem)
+                queue[index].emailDeliveredAt = .now
+                queue[index].lastError = nil
+            }
+            if queue[index].needsGoodLinksDelivery {
+                try await saveGoodLinksCopyIfNeeded(for: queue[index])
+                queue[index].goodLinksDeliveredAt = .now
+                queue[index].goodLinksLastError = nil
+            }
+            if queue[index].isFullyDelivered {
+                removeManagedMedia(for: queuedItem)
+                queue.remove(at: index)
+            }
             try QueueStore.save(queue)
             return true
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            queue[index].lastError = error.localizedDescription
+            if queue[index].needsEmailDelivery {
+                queue[index].lastError = error.localizedDescription
+            } else {
+                queue[index].goodLinksLastError = error.localizedDescription
+            }
             try QueueStore.save(queue)
             throw error
         }
@@ -779,15 +845,31 @@ final class ShareExtensionModel: ObservableObject {
             try Task.checkCancellation()
 
             do {
-                try await deliveryService.sendEmail(using: session, item: next)
-                removeManagedMedia(for: next)
-                queue.removeLast()
+                let index = queue.count - 1
+                if queue[index].needsEmailDelivery {
+                    try await deliveryService.sendEmail(using: session, item: queue[index])
+                    queue[index].emailDeliveredAt = .now
+                    queue[index].lastError = nil
+                }
+                if queue[index].needsGoodLinksDelivery {
+                    try await saveGoodLinksCopyIfNeeded(for: queue[index])
+                    queue[index].goodLinksDeliveredAt = .now
+                    queue[index].goodLinksLastError = nil
+                }
+                if queue[index].isFullyDelivered {
+                    removeManagedMedia(for: next)
+                    queue.removeLast()
+                }
                 try QueueStore.save(queue)
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
                 if let index = queue.indices.last {
-                    queue[index].lastError = error.localizedDescription
+                    if queue[index].needsEmailDelivery {
+                        queue[index].lastError = error.localizedDescription
+                    } else {
+                        queue[index].goodLinksLastError = error.localizedDescription
+                    }
                     try QueueStore.save(queue)
                 }
                 throw error
@@ -814,6 +896,25 @@ final class ShareExtensionModel: ObservableObject {
             return false
         }
     }
+
+    private func saveGoodLinksCopyIfNeeded(for item: QueuedEmail) async throws {
+        guard item.goodLinksEnabled else {
+            return
+        }
+
+        let settings = GoodLinksSettingsStore.load()
+        #if os(macOS) || targetEnvironment(macCatalyst)
+        try await goodLinksService.saveUsingLocalAPI(item: item, settings: settings)
+        #else
+        try GoodLinksSyncStore.append(item: item, settings: settings)
+        #endif
+    }
+
+    #if os(macOS) || targetEnvironment(macCatalyst)
+    private func processSyncedGoodLinksQueueIfPossible() async {
+        _ = await GoodLinksSyncProcessor.drain(using: goodLinksService)
+    }
+    #endif
 
     private func promptForGmailConnectionIfNeeded() {
         guard !hasPromptedForGmailConnection, !hasSharedGmailSession else {


### PR DESCRIPTION
## Summary

Adds optional GoodLinks saving alongside the existing Gmail delivery path. Gmail remains the required/core send path; GoodLinks is treated as a bonus copy that can be retried independently.

## What changed

- Added a `GoodLinksService` for the local GoodLinks API, callback URL construction, metadata mapping, tags, starred/read options, and connection testing.
- Added a `GoodLinksSyncStore` backed by iCloud key-value storage so iPhone/iPad GoodLinks saves can queue for later Mac processing.
- Updated app queue processing so email delivery and GoodLinks delivery are tracked separately and retried without losing the original item.
- Added Mac queue UI for synced iPhone GoodLinks jobs with retry/delete controls.
- Added GoodLinks setup UI, chip-style tag editing, default `sendmoi` tag, connection status, guided setup copy, and clearer missing-token/server/error states.
- Added onboarding/settings guidance for the iOS caveat: silent GoodLinks saving requires the Mac local API, so iPhone/iPad items sync to the Mac queue.
- Added entitlements needed for iCloud KVS/app group queue sharing across the app and share extension.

## Why

GoodLinks only exposes a local Mac API for silent saving. Without a cloud/web API, iOS cannot silently add items directly. This keeps SendMoi’s main job simple: send the email first, then optionally save or queue a GoodLinks copy when the platform allows it.

## Notes and caveats

- On Mac, GoodLinks can save directly after the user pastes the API address/token from GoodLinks Settings > API.
- On iPhone/iPad, GoodLinks copies are queued through iCloud KVS and processed later by SendMoi on Mac.
- The Mac GoodLinks duplicate-save toggle controls Mac-origin shares only; pending iPhone GoodLinks queue items can still drain when the Mac has the API token.
- If GoodLinks is unavailable, missing a token, or returns an error, the item stays queued with visible retry state.

## Validation

- `xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -destination 'platform=macOS' -allowProvisioningUpdates build`
- `xcodebuild -project SendMoi.xcodeproj -scheme SendMoi -destination 'generic/platform=iOS Simulator' build`

Both builds passed after rebasing/harmonizing this branch on latest `origin/main`.
