### PR TITLE
Cap share-sheet send wait and time-box on-device summaries

### DIFF
--- a/SendMoi/Services/GmailDeliveryService.swift
+++ b/SendMoi/Services/GmailDeliveryService.swift
@@ -2983,33 +2983,63 @@ final class GmailDeliveryService {
         return refusalMarkers.contains { lowered.contains($0) }
     }
 
+    // The share extension sends under a delivery watchdog, so the on-device
+    // model gets a tight budget there before we fall back to the extractive
+    // summarizer; the main app's queue flush has no UI waiting on it and can
+    // afford more.
+    private static let summaryResponseDeadlineNanoseconds: UInt64 =
+        Bundle.main.bundleURL.pathExtension == "appex" ? 5_000_000_000 : 12_000_000_000
+
+    // Races an operation against a deadline. Unlike a task group, this does not
+    // wait for the losing operation to acknowledge cancellation — a model call
+    // that stalls without honoring cancellation is abandoned so the deadline
+    // holds. The abandoned task is left to finish (or die with the process).
+    private static func resultWithinDeadline<T: Sendable>(
+        nanoseconds: UInt64,
+        of operation: @escaping @Sendable () async -> T?
+    ) async -> T? {
+        let state = DeadlineRaceState()
+        return await withCheckedContinuation { continuation in
+            let work = Task {
+                let value = await operation()
+                if state.claimCompletion() {
+                    continuation.resume(returning: value)
+                }
+            }
+            Task {
+                try? await Task.sleep(nanoseconds: nanoseconds)
+                if state.claimCompletion() {
+                    work.cancel()
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+
     private static func summarizeWithFoundationModels(_ text: String, title: String, minWords: Int, maxWords: Int) async -> String? {
 #if canImport(FoundationModels)
         guard #available(iOS 26.0, macOS 26.0, visionOS 26.0, *) else {
             return nil
         }
 
-        let model = SystemLanguageModel.default
-        guard model.isAvailable else {
+        guard SystemLanguageModel.default.isAvailable else {
             return nil
         }
 
         let excerptSource = truncate(text, to: 700)
-        let session = LanguageModelSession(model: model) {
-            """
-            You summarize already-published web content for a read-later email.
-            Return plain text only.
-            Write between \(minWords) and \(maxWords) words when the source supports it.
-            Treat the content as a summary request, not advice, classification, or a safety review.
-            Summarize only what is already published in the provided source text.
-            Ignore image captions, credits, product listings, bylines, and promotional or subscription copy.
-            Be neutral, concise, and specific.
-            Do not repeat the title verbatim.
-            Focus on the main point of the page.
-            Do not introduce the summary with phrases like "Here is a summary" or "This post is about".
-            Start directly with the substance.
-            """
-        }
+        let instructions = """
+        You summarize already-published web content for a read-later email.
+        Return plain text only.
+        Write between \(minWords) and \(maxWords) words when the source supports it.
+        Treat the content as a summary request, not advice, classification, or a safety review.
+        Summarize only what is already published in the provided source text.
+        Ignore image captions, credits, product listings, bylines, and promotional or subscription copy.
+        Be neutral, concise, and specific.
+        Do not repeat the title verbatim.
+        Focus on the main point of the page.
+        Do not introduce the summary with phrases like "Here is a summary" or "This post is about".
+        Start directly with the substance.
+        """
 
         let prompt = """
         Summarize this content for an email digest.
@@ -3020,29 +3050,36 @@ final class GmailDeliveryService {
         \(excerptSource)
         """
 
-        do {
-            let response = try await session.respond(
+        let responseContent = await resultWithinDeadline(
+            nanoseconds: summaryResponseDeadlineNanoseconds
+        ) { () -> String? in
+            let session = LanguageModelSession(model: .default) { instructions }
+            let response = try? await session.respond(
                 to: prompt,
                 options: GenerationOptions(maximumResponseTokens: 180)
             )
-            let normalized = stripSummaryPreamble(
-                from: collapseWhitespace(in: response.content),
-                title: title
-            )
-            guard !normalized.isEmpty else {
-                return nil
-            }
-            guard !looksLikeModelRefusal(normalized) else {
-                return nil
-            }
-            let clamped = truncate(normalized, to: maxWords)
-            guard wordCount(in: clamped) >= minWords else {
-                return nil
-            }
-            return clamped
-        } catch {
+            return response?.content
+        }
+
+        guard let responseContent else {
             return nil
         }
+
+        let normalized = stripSummaryPreamble(
+            from: collapseWhitespace(in: responseContent),
+            title: title
+        )
+        guard !normalized.isEmpty else {
+            return nil
+        }
+        guard !looksLikeModelRefusal(normalized) else {
+            return nil
+        }
+        let clamped = truncate(normalized, to: maxWords)
+        guard wordCount(in: clamped) >= minWords else {
+            return nil
+        }
+        return clamped
 #else
         return nil
 #endif
@@ -3247,6 +3284,22 @@ private actor PreviewMetadataCache {
     private func touch(_ urlString: String) {
         keysInAccessOrder.removeAll { $0 == urlString }
         keysInAccessOrder.append(urlString)
+    }
+}
+
+// First-completion-wins flag for racing an operation against a deadline.
+private final class DeadlineRaceState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var finished = false
+
+    func claimCompletion() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if finished {
+            return false
+        }
+        finished = true
+        return true
     }
 }
 

--- a/SendMoiShare/ShareExtensionModel.swift
+++ b/SendMoiShare/ShareExtensionModel.swift
@@ -15,8 +15,8 @@ import AppKit
 final class ShareExtensionModel: ObservableObject {
     private static let autoSendGracePeriodNanoseconds: UInt64 = 1_500_000_000
     private static let autoSendCommitFlashNanoseconds: UInt64 = 200_000_000
-    private static let autoSendPreviewWaitLimitNanoseconds: UInt64 = 6_000_000_000
-    private static let autoSendDeliveryTimeoutNanoseconds: UInt64 = 15_000_000_000
+    private static let autoSendPreviewWaitLimitNanoseconds: UInt64 = 4_000_000_000
+    private static let deliveryTimeoutNanoseconds: UInt64 = 8_000_000_000
     private static let manualSendPreviewWaitLimitNanoseconds: UInt64 = 750_000_000
     static let missingRecipientMessage = "Enter a recipient in the To field, or set a default recipient in the SendMoi app."
     static let recipientHelperMessage = "Pro tip: add a recipient here, or save a default recipient in the SendMoi app."
@@ -139,22 +139,31 @@ final class ShareExtensionModel: ObservableObject {
         let item = makeQueuedEmail(from: draft)
 
         isSaving = true
+        pendingAutoSendItem = item
 
         if shouldAllowAutoSendEditWindow {
             canChangeAutoSendRecipient = true
             allowsAutoSendEdit = true
-            pendingAutoSendItem = item
-            deliveryTimeoutTask = Task { [weak self] in
-                guard let self else { return }
-                try? await Task.sleep(
-                    nanoseconds: Self.autoSendGracePeriodNanoseconds
-                        + Self.autoSendCommitFlashNanoseconds
-                        + Self.autoSendDeliveryTimeoutNanoseconds
-                )
-                guard !Task.isCancelled, self.isSaving, let pending = self.pendingAutoSendItem else { return }
+        }
+
+        // Watchdog: if delivery hasn't finished by the deadline, queue the item
+        // for the next launch (share extension or main app) and close the sheet.
+        // Cancelling the send task first keeps a late-succeeding send from also
+        // leaving the item queued.
+        let watchdogDelayNanoseconds = shouldAllowAutoSendEditWindow
+            ? Self.autoSendGracePeriodNanoseconds
+                + Self.autoSendCommitFlashNanoseconds
+                + Self.deliveryTimeoutNanoseconds
+            : Self.deliveryTimeoutNanoseconds
+        deliveryTimeoutTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: watchdogDelayNanoseconds)
+            guard !Task.isCancelled, self.isSaving else { return }
+            self.sendTask?.cancel()
+            if let pending = self.pendingAutoSendItem {
                 try? QueueStore.append(pending)
-                self.extensionContextRef?.completeRequest(returningItems: nil, completionHandler: nil)
             }
+            self.extensionContextRef?.completeRequest(returningItems: nil, completionHandler: nil)
         }
 
         sendTask = Task { [weak self] in


### PR DESCRIPTION
## Problem

On iOS 27 beta 2 the share extension sits on "Sending to …" for the full 15-second delivery watchdog before the sheet closes (confirmed by frame-timing a screen recording: the spinner ran 15.3 s — exactly the watchdog, not a slow-but-successful send). The root cause is that `summarizeWithFoundationModels` calls `LanguageModelSession.respond` with no deadline, and the send pipeline blocks the sheet on it. Manual sends had no watchdog at all.

## Changes

- **Time-box the Foundation Models summary call** (`GmailDeliveryService`): the model call now races a deadline — 5 s inside app extensions, 12 s in the main app — and falls back to the existing extractive summarizer when it doesn't finish. The race resumes at the deadline even if the model call never honors cancellation, so a stalled call can no longer pin the pipeline.
- **Shorten the share-extension delivery watchdog** from 15 s to 8 s, and the auto-send preview wait from 6 s to 4 s (`ShareExtensionModel`). On timeout the item is queued to the shared container and delivered on the next share-extension or main-app launch, as before.
- **Arm the watchdog for manual sends too**, which previously could spin forever, and make it close the sheet even in the send-succeeded-but-backlog-flush-stalled case (it previously bailed out when `pendingAutoSendItem` was already nil).
- **Cancel the in-flight send task before the watchdog queues the item**, narrowing the window where a late-succeeding send could also leave a duplicate in the queue.

## Expected behavior after this change

Worst case in the share sheet is now ~1.7 s grace window + 8 s delivery budget (~10 s total, down from ~17 s), and the common case should return to a few seconds since the summary can no longer stall the send. Anything that misses the budget goes to the queue and sends on next launch.

## Verification

Reviewed against the recorded repro timeline; this environment has no Apple toolchain, so the project still needs a local build and an on-device share-sheet pass (ideally on the iOS 27 beta where the stall reproduces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQtwSxCBhKa3deMHMZvL8e

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQtwSxCBhKa3deMHMZvL8e)_